### PR TITLE
Allow Replit host for Vite dev and preview servers

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,10 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    allowedHosts: [".replit.dev"],
+  },
+  preview: {
+    allowedHosts: [".replit.dev"],
   },
   plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
   resolve: {


### PR DESCRIPTION
## Summary
- allow Replit proxy host in the Vite dev server configuration so the forwarded URL works
- mirror the host allow-list for `vite preview` to avoid the same block when previewing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb558983fc8324860842e4f56a0387