### PR TITLE
Implement settings management and theming

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -43,6 +43,8 @@ import {
 import { useAuthStore } from '@/stores/auth';
 import { NavLink } from 'react-router-dom';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useQuery } from '@tanstack/react-query';
+import { mockApi } from '@/mocks/api';
 
 const sidebarItems = [
   { title: 'Dashboard', url: '/app', icon: LayoutDashboard, active: true },
@@ -51,14 +53,18 @@ const sidebarItems = [
   { title: 'Documents', url: '/documents', icon: FileText, disabled: true },
   { title: 'Issues', url: '/issues', icon: AlertTriangle, disabled: true },
   { title: 'Reports', url: '/reports', icon: BarChart3, disabled: true },
-  { title: 'Settings', url: '/settings', icon: Settings, disabled: true },
+  { title: 'Settings', url: '/settings', icon: Settings, disabled: false },
 ];
 
 const AppSidebar = () => {
   const { state } = useSidebar();
   const location = useLocation();
   const collapsed = state === 'collapsed';
-  
+  const { data: orgSettings } = useQuery({
+    queryKey: ['org-settings'],
+    queryFn: () => mockApi.getOrgSettings(),
+  });
+
   const isActive = (path: string) => location.pathname === path;
 
   return (
@@ -66,7 +72,7 @@ const AppSidebar = () => {
       <SidebarContent>
         <SidebarGroup>
           <SidebarGroupLabel className={collapsed ? "sr-only" : ""}>
-            ProList
+            {orgSettings?.name ?? 'ProList'}
           </SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
@@ -114,6 +120,10 @@ export const AppShell = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const { user, logout } = useAuthStore();
   const navigate = useNavigate();
+  const { data: orgSettings } = useQuery({
+    queryKey: ['org-settings'],
+    queryFn: () => mockApi.getOrgSettings(),
+  });
 
   const handleLogout = async () => {
     await logout();
@@ -135,7 +145,19 @@ export const AppShell = () => {
           <header className="h-14 flex items-center justify-between px-4 border-b border-border bg-background/95 backdrop-blur-sm">
             <div className="flex items-center gap-4">
               <SidebarTrigger />
-              
+              <div className="flex min-w-0 items-center gap-3">
+                {orgSettings?.logoDataUrl && (
+                  <img
+                    src={orgSettings.logoDataUrl}
+                    alt={`${orgSettings.name ?? 'Organisation'} logo`}
+                    className="h-8 w-8 rounded-xl object-contain"
+                  />
+                )}
+                <span className="max-w-[200px] truncate text-lg font-semibold text-foreground">
+                  {orgSettings?.name ?? 'ProList'}
+                </span>
+              </div>
+
               {/* Search */}
               <div className="relative hidden md:block">
                 <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -1,154 +1,62 @@
-// Settings page with demo reset functionality
-
 import { useState } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { useToast } from '@/hooks/use-toast';
-import { mockApi } from '@/mocks/api';
-import { RotateCcw, AlertTriangle, CheckCircle, Settings } from 'lucide-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { OrganisationSettingsTab } from './components/OrganisationSettingsTab';
+import { BrandingSettingsTab } from './components/BrandingSettingsTab';
+import { TemplatesSettingsTab } from './components/TemplatesSettingsTab';
+import { RolesUsersSettingsTab } from './components/RolesUsersSettingsTab';
+import { WorkspaceSettingsTab } from './components/WorkspaceSettingsTab';
+
+const SETTINGS_TABS = [
+  { value: 'organisation', label: 'Organisation' },
+  { value: 'branding', label: 'Branding' },
+  { value: 'templates', label: 'Templates' },
+  { value: 'roles', label: 'Roles & Users' },
+  { value: 'workspace', label: 'Workspace' },
+] as const;
+
+type SettingsTabValue = (typeof SETTINGS_TABS)[number]['value'];
 
 export const SettingsPage = () => {
-  const [isResetting, setIsResetting] = useState(false);
-  const { toast } = useToast();
-
-  const handleDemoReset = async () => {
-    setIsResetting(true);
-    
-    try {
-      await mockApi.resetDemo();
-      
-      toast({
-        title: "Demo Reset Complete",
-        description: "All demo data has been reset to initial state.",
-        duration: 5000,
-      });
-      
-      // Reload the page to reflect the reset data
-      setTimeout(() => {
-        window.location.reload();
-      }, 1000);
-      
-    } catch (error) {
-      console.error('Demo reset failed:', error);
-      
-      toast({
-        title: "Reset Failed",
-        description: "Failed to reset demo data. Please try again.",
-        variant: "destructive",
-        duration: 5000,
-      });
-    } finally {
-      setIsResetting(false);
-    }
-  };
+  const [activeTab, setActiveTab] = useState<SettingsTabValue>('organisation');
 
   return (
-    <div className="space-y-8">
-      {/* Page Header */}
-      <div>
-        <h1 className="text-3xl font-bold text-foreground">Settings</h1>
-        <p className="text-muted-foreground">Manage your account and workspace configuration</p>
-      </div>
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-bold">Settings</h1>
+        <p className="text-muted-foreground">
+          Manage organisation, branding, templates, and workspace.
+        </p>
+      </header>
 
-      {/* Demo Section */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Settings className="h-5 w-5" />
-            Demo Environment
-          </CardTitle>
-          <CardDescription>
-            This is a demonstration environment with mock data. You can reset the demo data at any time.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <Alert>
-            <CheckCircle className="h-4 w-4" />
-            <AlertDescription>
-              Demo mode is active. All data is stored locally and will not affect real systems.
-            </AlertDescription>
-          </Alert>
-
-          <div className="space-y-3">
-            <h4 className="font-medium text-foreground">Reset Demo Data</h4>
-            <p className="text-sm text-muted-foreground">
-              This will restore all shipments, KPIs, and other demo data to their initial state. 
-              This action cannot be undone.
-            </p>
-            
-            <Button 
-              onClick={handleDemoReset}
-              disabled={isResetting}
-              variant="outline"
-              className="flex items-center gap-2"
+      <Tabs value={activeTab} onValueChange={value => setActiveTab(value as SettingsTabValue)}>
+        <TabsList className="flex flex-wrap justify-start gap-2 rounded-full bg-muted/60 p-1">
+          {SETTINGS_TABS.map(tab => (
+            <TabsTrigger
+              key={tab.value}
+              value={tab.value}
+              className="rounded-full px-4 py-2 text-sm font-medium data-[state=active]:bg-background data-[state=active]:text-foreground"
             >
-              <RotateCcw className={`h-4 w-4 ${isResetting ? 'animate-spin' : ''}`} />
-              {isResetting ? 'Resetting...' : 'Reset Demo Data'}
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+              {tab.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
 
-      {/* Coming Soon Sections */}
-      <div className="grid md:grid-cols-2 gap-6">
-        <Card className="opacity-60">
-          <CardHeader>
-            <CardTitle>Account Settings</CardTitle>
-            <CardDescription>Coming soon</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Manage your profile, preferences, and account security settings.
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card className="opacity-60">
-          <CardHeader>
-            <CardTitle>Compliance Rules</CardTitle>
-            <CardDescription>Coming soon</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Configure custom compliance rules and document requirements.
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card className="opacity-60">
-          <CardHeader>
-            <CardTitle>Team Management</CardTitle>
-            <CardDescription>Coming soon</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Invite team members and manage user permissions.
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card className="opacity-60">
-          <CardHeader>
-            <CardTitle>Integrations</CardTitle>
-            <CardDescription>Coming soon</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Connect with external systems and APIs for automated workflows.
-            </p>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Warning */}
-      <Alert variant="destructive">
-        <AlertTriangle className="h-4 w-4" />
-        <AlertDescription>
-          <strong>Demo Environment:</strong> This is a demonstration version of ProList. 
-          Features marked as "Coming soon" are not yet implemented in this preview.
-        </AlertDescription>
-      </Alert>
+        <TabsContent value="organisation" className="mt-6">
+          <OrganisationSettingsTab />
+        </TabsContent>
+        <TabsContent value="branding" className="mt-6">
+          <BrandingSettingsTab />
+        </TabsContent>
+        <TabsContent value="templates" className="mt-6">
+          <TemplatesSettingsTab />
+        </TabsContent>
+        <TabsContent value="roles" className="mt-6">
+          <RolesUsersSettingsTab />
+        </TabsContent>
+        <TabsContent value="workspace" className="mt-6">
+          <WorkspaceSettingsTab />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 };

--- a/src/features/settings/components/BrandingSettingsTab.tsx
+++ b/src/features/settings/components/BrandingSettingsTab.tsx
@@ -1,0 +1,281 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { mockApi } from '@/mocks/api';
+import type { BrandSettings } from '@/mocks/types';
+import { useToast } from '@/hooks/use-toast';
+
+const colourKeys: Array<{ key: keyof BrandSettings; label: string; helper: string }> = [
+  { key: 'primary', label: 'Primary', helper: 'Buttons and key highlights' },
+  { key: 'accentBlue', label: 'Accent blue', helper: 'Alerts and badges' },
+  { key: 'accentTeal', label: 'Accent teal', helper: 'Secondary accents' },
+  { key: 'accentGreen', label: 'Accent green', helper: 'Approvals and success states' },
+  { key: 'accentMint', label: 'Accent mint', helper: 'Soft backgrounds' },
+];
+
+const hexPattern = /^#([0-9a-fA-F]{6})$/;
+
+const parseHex = (hex: string) => {
+  const cleaned = hex.trim();
+  return hexPattern.test(cleaned) ? cleaned.toUpperCase() : null;
+};
+
+const hexToRgb = (hex: string) => {
+  const match = hex.replace('#', '');
+  const bigint = Number.parseInt(match, 16);
+  const r = (bigint >> 16) & 255;
+  const g = (bigint >> 8) & 255;
+  const b = bigint & 255;
+  return [r / 255, g / 255, b / 255];
+};
+
+const luminance = (hex: string) => {
+  const [r, g, b] = hexToRgb(hex).map(channel => {
+    return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+const contrastRatio = (hexA: string, hexB: string) => {
+  const lumA = luminance(hexA);
+  const lumB = luminance(hexB);
+  const lighter = Math.max(lumA, lumB);
+  const darker = Math.min(lumA, lumB);
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+const readableTextColour = (hex: string) => {
+  return luminance(hex) > 0.5 ? '#111827' : '#FFFFFF';
+};
+
+export const BrandingSettingsTab = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const { data, isLoading } = useQuery({
+    queryKey: ['brand-settings'],
+    queryFn: () => mockApi.getBrandSettings(),
+  });
+
+  const [preview, setPreview] = useState<BrandSettings | null>(null);
+  const [draft, setDraft] = useState<Record<keyof BrandSettings, string> | null>(null);
+
+  useEffect(() => {
+    if (data) {
+      setPreview(data);
+      setDraft({ ...data });
+    }
+  }, [data]);
+
+  const saveMutation = useMutation({
+    mutationFn: (payload: Partial<BrandSettings>) => mockApi.saveBrandSettings(payload),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(['brand-settings'], updated);
+      setPreview(updated);
+      setDraft({ ...updated });
+      toast({ title: 'Branding updated', description: 'Theme colours refreshed across the workspace.' });
+    },
+    onError: () => {
+      toast({ title: 'Unable to save', description: 'Please check your colour values and try again.', variant: 'destructive' });
+    },
+  });
+
+  const resetMutation = useMutation({
+    mutationFn: () => mockApi.resetBrandSettings(),
+    onSuccess: (defaults) => {
+      queryClient.setQueryData(['brand-settings'], defaults);
+      setPreview(defaults);
+      setDraft({ ...defaults });
+      toast({ title: 'Branding reset', description: 'Reverted to the original ProList palette.' });
+    },
+    onError: () => {
+      toast({ title: 'Reset failed', description: 'We could not restore the defaults this time.', variant: 'destructive' });
+    },
+  });
+
+  const handleHexChange = (key: keyof BrandSettings, value: string) => {
+    if (!preview || !draft) return;
+    const upper = value.startsWith('#') ? value.toUpperCase() : `#${value.toUpperCase()}`;
+    if (upper.length > 7) {
+      return;
+    }
+    const nextDraft = { ...draft, [key]: upper };
+    setDraft(nextDraft);
+    if (parseHex(upper)) {
+      setPreview({ ...preview, [key]: upper });
+    }
+  };
+
+  const handleColourPickerChange = (key: keyof BrandSettings, value: string) => {
+    if (!preview || !draft) return;
+    const next = value.toUpperCase();
+    setPreview({ ...preview, [key]: next });
+    setDraft({ ...draft, [key]: next });
+  };
+
+  const hasChanges = useMemo(() => {
+    if (!preview || !data) return false;
+    return JSON.stringify(preview) !== JSON.stringify(data);
+  }, [preview, data]);
+
+  const contrast = useMemo(() => {
+    if (!preview) {
+      return { ratio: 0, passes: false };
+    }
+    const ratio = contrastRatio(preview.primary, '#FFFFFF');
+    return { ratio, passes: ratio >= 4.5 };
+  }, [preview]);
+
+  if (isLoading && !preview) {
+    return (
+      <div className="grid gap-6 lg:grid-cols-[3fr_2fr]">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-4 w-72" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-64 w-full" />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-48" />
+          </CardHeader>
+          <CardContent className="space-y-5">
+            {colourKeys.map(({ key }) => (
+              <div key={key} className="space-y-2">
+                <Skeleton className="h-4 w-28" />
+                <div className="flex gap-3">
+                  <Skeleton className="h-10 w-24" />
+                  <Skeleton className="h-10 flex-1" />
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!preview || !draft) {
+    return null;
+  }
+
+  const textOnPrimary = readableTextColour(preview.primary);
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[3fr_2fr]">
+      <Card>
+        <CardHeader>
+          <CardTitle>Theme preview</CardTitle>
+          <CardDescription>Colours update instantly when you save. Use this preview to check contrast and tone.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-3xl border bg-gradient-to-br from-muted/60 to-background p-6 shadow-sm">
+            <div className="mb-6 grid gap-4 md:grid-cols-2">
+              <button
+                type="button"
+                style={{ backgroundColor: preview.primary, color: textOnPrimary }}
+                className="rounded-2xl px-4 py-3 text-sm font-semibold shadow-md transition-colors"
+              >
+                Primary action
+              </button>
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-full border px-3 py-1 text-xs font-semibold" style={{ borderColor: preview.accentBlue, color: preview.accentBlue }}>
+                  Accent blue
+                </span>
+                <span className="rounded-full border px-3 py-1 text-xs font-semibold" style={{ borderColor: preview.accentTeal, color: preview.accentTeal }}>
+                  Accent teal
+                </span>
+                <span className="rounded-full border px-3 py-1 text-xs font-semibold" style={{ borderColor: preview.accentGreen, color: preview.accentGreen }}>
+                  Accent green
+                </span>
+                <span className="rounded-full border px-3 py-1 text-xs font-semibold" style={{ borderColor: preview.accentMint, color: preview.accentMint }}>
+                  Accent mint
+                </span>
+              </div>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="rounded-2xl border bg-white/80 p-4 shadow-sm">
+                <p className="text-sm font-semibold" style={{ color: preview.primary }}>Highlighted card</p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Use cards to surface key shipment KPIs and tracking updates.
+                </p>
+              </div>
+              <div className="rounded-2xl border bg-white/80 p-4 shadow-sm">
+                <div className="flex items-center gap-2">
+                  <div className="h-2 w-2 rounded-full" style={{ backgroundColor: preview.accentGreen }} />
+                  <p className="text-sm font-semibold">Status: Ready</p>
+                </div>
+                <p className="mt-2 text-sm text-muted-foreground">Brand accents support alerts and secondary UI moments.</p>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Colour controls</CardTitle>
+          <CardDescription>Adjust the palette and save to push the new theme instantly.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="space-y-5">
+            {colourKeys.map(({ key, label, helper }) => (
+              <div key={key} className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium">{label}</p>
+                    <p className="text-xs text-muted-foreground">{helper}</p>
+                  </div>
+                  <Input
+                    type="color"
+                    value={preview[key]}
+                    onChange={(event) => handleColourPickerChange(key, event.target.value)}
+                    className="h-10 w-16 cursor-pointer border bg-transparent"
+                    aria-label={`${label} colour picker`}
+                  />
+                </div>
+                <Input
+                  value={draft[key]}
+                  onChange={(event) => handleHexChange(key, event.target.value)}
+                  className="font-mono uppercase"
+                  aria-label={`${label} hex value`}
+                />
+              </div>
+            ))}
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Badge variant={contrast.passes ? 'secondary' : 'destructive'} className="px-3 py-1 text-xs font-semibold">
+              {contrast.passes ? 'AA pass' : 'Contrast fail'} · {contrast.ratio.toFixed(2)}:1
+            </Badge>
+            {!contrast.passes && (
+              <p className="text-xs text-muted-foreground">Try a darker primary so white text remains legible.</p>
+            )}
+          </div>
+          <div className="flex flex-wrap justify-end gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => resetMutation.mutate()}
+              disabled={resetMutation.isPending}
+            >
+              {resetMutation.isPending ? 'Resetting…' : 'Reset to defaults'}
+            </Button>
+            <Button
+              type="button"
+              onClick={() => preview && saveMutation.mutate(preview)}
+              disabled={!hasChanges || saveMutation.isPending}
+            >
+              {saveMutation.isPending ? 'Saving…' : 'Save theme'}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/features/settings/components/OrganisationSettingsTab.tsx
+++ b/src/features/settings/components/OrganisationSettingsTab.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Skeleton } from '@/components/ui/skeleton';
+import { mockApi } from '@/mocks/api';
+import type { OrgSettings } from '@/mocks/types';
+import { useToast } from '@/hooks/use-toast';
+import { Upload, ImageIcon } from 'lucide-react';
+import { fileToDataUrl } from '@/utils/file';
+
+const REQUIRED_MESSAGE = 'This field is required.';
+
+export const OrganisationSettingsTab = () => {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['org-settings'],
+    queryFn: () => mockApi.getOrgSettings(),
+  });
+
+  const form = useForm<OrgSettings>({
+    defaultValues: {
+      name: '',
+      email: '',
+      phone: '',
+      tax_id: '',
+      country: '',
+      city: '',
+      address: '',
+      logoDataUrl: '',
+    },
+    mode: 'onBlur',
+  });
+
+  useEffect(() => {
+    if (data) {
+      form.reset(data);
+    }
+  }, [data, form]);
+
+  const saveMutation = useMutation({
+    mutationFn: (payload: Partial<OrgSettings>) => mockApi.saveOrgSettings(payload),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(['org-settings'], updated);
+      form.reset(updated);
+      toast({ title: 'Saved', description: 'Organisation settings have been updated.' });
+    },
+    onError: () => {
+      toast({ title: 'Save failed', description: 'We could not save your changes just now.', variant: 'destructive' });
+    },
+  });
+
+  const handleSubmit = (values: OrgSettings) => {
+    saveMutation.mutate(values);
+  };
+
+  const handleLogoClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleLogoChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    const allowedTypes = ['image/png', 'image/jpeg', 'image/jpg', 'image/svg+xml'];
+    if (!allowedTypes.includes(file.type)) {
+      toast({ title: 'Unsupported file', description: 'Please upload a PNG, JPG, or SVG logo.', variant: 'destructive' });
+      event.target.value = '';
+      return;
+    }
+
+    try {
+      const dataUrl = await fileToDataUrl(file);
+      saveMutation.mutate(
+        { logoDataUrl: dataUrl },
+        {
+          onSuccess: (updated) => {
+            queryClient.setQueryData(['org-settings'], updated);
+            toast({ title: 'Logo updated', description: 'Your organisation logo now appears across the workspace.' });
+          },
+        },
+      );
+    } catch (error) {
+      console.error('Logo upload failed', error);
+      toast({ title: 'Upload failed', description: 'We could not read that file. Try a smaller logo.', variant: 'destructive' });
+    } finally {
+      event.target.value = '';
+    }
+  };
+
+  if (isLoading && !data) {
+    return (
+      <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-4 w-64" />
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {Array.from({ length: 6 }).map((_, index) => (
+              <div key={index} className="space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-32" />
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Skeleton className="h-32 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+      <Card>
+        <CardHeader>
+          <CardTitle>Organisation profile</CardTitle>
+          <CardDescription>Update the details that appear on your documents and workspace.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form className="space-y-6" onSubmit={form.handleSubmit(handleSubmit)}>
+              <div className="grid gap-6 md:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  rules={{ required: REQUIRED_MESSAGE }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Name</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="ProList Manufacturing" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="tax_id"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Tax ID</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="CM-PL-009988" />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="email"
+                  rules={{
+                    validate: (value) => {
+                      if (!value) return true;
+                      return /.+@.+\..+/.test(value) || 'Enter a valid e-mail address.';
+                    },
+                  }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>E-mail</FormLabel>
+                      <FormControl>
+                        <Input {...field} type="email" placeholder="hello@prolist.example" autoComplete="email" />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="phone"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Phone</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="(+237) 222 123 456" autoComplete="tel" />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="country"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Country</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="Cameroon" />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="city"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>City</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder="Bamenda" />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <FormField
+                control={form.control}
+                name="address"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Address</FormLabel>
+                    <FormControl>
+                      <Textarea {...field} rows={3} placeholder="Street, district, city" />
+                    </FormControl>
+                    <FormDescription>The full address is included on commercial invoices and certificates.</FormDescription>
+                  </FormItem>
+                )}
+              />
+              <div className="flex justify-end">
+                <Button
+                  type="submit"
+                  disabled={!form.formState.isDirty || saveMutation.isPending}
+                  className="min-w-[140px]"
+                >
+                  {saveMutation.isPending ? 'Saving…' : 'Save changes'}
+                </Button>
+              </div>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Logo</CardTitle>
+          <CardDescription>Your logo appears in the navigation bar and exported documents.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-2xl border bg-muted/40 p-6 text-center shadow-sm">
+            {data?.logoDataUrl ? (
+              <img
+                src={data.logoDataUrl}
+                alt={`${data.name ?? 'Organisation'} logo`}
+                className="mx-auto h-24 w-auto max-w-[160px] object-contain"
+              />
+            ) : (
+              <div className="flex flex-col items-center justify-center gap-3 text-muted-foreground">
+                <ImageIcon className="h-10 w-10" />
+                <p className="text-sm">No logo uploaded yet</p>
+              </div>
+            )}
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/svg+xml"
+            className="hidden"
+            onChange={handleLogoChange}
+          />
+          <Button onClick={handleLogoClick} variant="outline" className="w-full">
+            <Upload className="mr-2 h-4 w-4" />
+            Upload logo
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            PNG, JPG, or SVG up to 2 MB. Square logos sit best in the header.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/features/settings/components/RolesUsersSettingsTab.tsx
+++ b/src/features/settings/components/RolesUsersSettingsTab.tsx
@@ -1,0 +1,169 @@
+import { useMemo } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Skeleton } from '@/components/ui/skeleton';
+import { mockApi } from '@/mocks/api';
+import type { AppRole } from '@/mocks/types';
+import { useToast } from '@/hooks/use-toast';
+import { Check } from 'lucide-react';
+
+const CAPABILITIES: Array<{ key: string; label: string }> = [
+  { key: 'view_shipments', label: 'View shipments' },
+  { key: 'manage_shipments', label: 'Create/Edit shipments' },
+  { key: 'generate_docs', label: 'Generate docs' },
+  { key: 'approve_docs', label: 'Approve docs' },
+  { key: 'manage_costs', label: 'Manage costs' },
+  { key: 'manage_issues', label: 'Manage issues' },
+  { key: 'manage_settings', label: 'Manage settings' },
+];
+
+const ROLE_MATRIX: Record<AppRole, string[]> = {
+  exporter_admin: CAPABILITIES.map(cap => cap.key),
+  broker: ['view_shipments', 'manage_shipments', 'generate_docs', 'approve_docs', 'manage_issues'],
+  finance: ['view_shipments', 'approve_docs', 'manage_costs'],
+  viewer: ['view_shipments'],
+};
+
+const ROLE_LABELS: Record<AppRole, string> = {
+  exporter_admin: 'Exporter admin',
+  broker: 'Broker',
+  finance: 'Finance',
+  viewer: 'Viewer',
+};
+
+export const RolesUsersSettingsTab = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const { data: users = [], isLoading } = useQuery({
+    queryKey: ['app-users'],
+    queryFn: () => mockApi.listUsers(),
+  });
+
+  const mutation = useMutation({
+    mutationFn: ({ userId, role }: { userId: string; role: AppRole }) => mockApi.updateUserRole(userId, role),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['app-users'] });
+      toast({ title: 'Role updated', description: 'The change takes effect immediately.' });
+    },
+    onError: () => {
+      toast({ title: 'Unable to update role', description: 'Please try again in a moment.', variant: 'destructive' });
+    },
+  });
+
+  const roleOrder = useMemo(() => Object.keys(ROLE_MATRIX) as AppRole[], []);
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[3fr_2fr]">
+      <Card>
+        <CardHeader>
+          <CardTitle>Role matrix</CardTitle>
+          <CardDescription>Reference which responsibilities are enabled for each workspace role.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Capability</TableHead>
+                  {roleOrder.map(role => (
+                    <TableHead key={role}>{ROLE_LABELS[role]}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {CAPABILITIES.map(capability => (
+                  <TableRow key={capability.key}>
+                    <TableCell className="font-medium">{capability.label}</TableCell>
+                    {roleOrder.map(role => (
+                      <TableCell key={role} className="text-center">
+                        {ROLE_MATRIX[role].includes(capability.key) ? (
+                          <Check className="mx-auto h-4 w-4 text-[var(--brand-primary)]" aria-label="Allowed" />
+                        ) : (
+                          <span className="sr-only">Not allowed</span>
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Users</CardTitle>
+          <CardDescription>Adjust roles to manage workspace responsibilities.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {isLoading ? (
+            <div className="space-y-4">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div key={index} className="flex items-center gap-3">
+                  <Skeleton className="h-10 w-10 rounded-full" />
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="h-3 w-32" />
+                  </div>
+                  <Skeleton className="h-10 w-36" />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {users.map(user => (
+                <div key={user.id} className="flex flex-col gap-3 rounded-2xl border bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between">
+                  <div className="flex items-center gap-3">
+                    <Avatar className="h-10 w-10">
+                      <AvatarFallback className="bg-[var(--brand-primary)] text-[color:var(--brand-primary-contrast)]">
+                        {user.name
+                          .split(' ')
+                          .map(part => part[0])
+                          .join('')
+                          .slice(0, 2)
+                          .toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div>
+                      <p className="text-sm font-semibold">{user.name}</p>
+                      <p className="text-xs text-muted-foreground">{user.email}</p>
+                      <Badge variant="secondary" className="mt-1 text-xs">
+                        Joined {new Date(user.created_at).toLocaleDateString('en-GB')}
+                      </Badge>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <label className="text-xs font-medium text-muted-foreground" htmlFor={`role-${user.id}`}>
+                      Role
+                    </label>
+                    <Select
+                      value={user.role}
+                      onValueChange={value => mutation.mutate({ userId: user.id, role: value as AppRole })}
+                      disabled={mutation.isPending}
+                    >
+                      <SelectTrigger id={`role-${user.id}`} className="w-40">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {roleOrder.map(role => (
+                          <SelectItem key={role} value={role}>
+                            {ROLE_LABELS[role]}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/src/features/settings/components/TemplatesSettingsTab.tsx
+++ b/src/features/settings/components/TemplatesSettingsTab.tsx
@@ -1,0 +1,308 @@
+import { useMemo, useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Skeleton } from '@/components/ui/skeleton';
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
+import { mockApi } from '@/mocks/api';
+import type { TemplateKey } from '@/mocks/types';
+import { useToast } from '@/hooks/use-toast';
+import { downloadDataUrl } from '@/utils/download';
+import { CloudUpload, Trash2, Check, Download } from 'lucide-react';
+
+const TEMPLATE_OPTIONS: Array<{ value: TemplateFilterValue; label: string; key: TemplateKey }> = [
+  { value: 'commercial_invoice', label: 'Commercial invoice', key: 'INVOICE' },
+  { value: 'packing_list', label: 'Packing list', key: 'PACKING_LIST' },
+  { value: 'certificate_of_origin', label: 'Certificate of Origin', key: 'COO' },
+  { value: 'phytosanitary_certificate', label: 'Phytosanitary certificate', key: 'PHYTO' },
+  { value: 'insurance_certificate', label: 'Insurance certificate', key: 'INSURANCE' },
+  { value: 'bill_of_lading', label: 'Bill of lading', key: 'BILL_OF_LADING' },
+  { value: 'customs_export_declaration', label: 'Customs export declaration', key: 'CUSTOMS_EXPORT_DECLARATION' },
+];
+
+const TEMPLATE_LABELS: Record<TemplateKey, string> = TEMPLATE_OPTIONS.reduce((acc, option) => {
+  acc[option.key] = option.label;
+  return acc;
+}, {} as Record<TemplateKey, string>);
+
+type TemplateFilterValue =
+  | 'all'
+  | 'commercial_invoice'
+  | 'packing_list'
+  | 'certificate_of_origin'
+  | 'phytosanitary_certificate'
+  | 'insurance_certificate'
+  | 'bill_of_lading'
+  | 'customs_export_declaration';
+
+const ACCEPTED_TYPES = ['application/pdf', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'application/msword'];
+
+const formatBytes = (bytes: number) => {
+  if (!bytes) return '0 KB';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+export const TemplatesSettingsTab = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [filter, setFilter] = useState<TemplateFilterValue>('all');
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+
+  const { data: templates = [], isLoading } = useQuery({
+    queryKey: ['templates'],
+    queryFn: () => mockApi.listTemplates(),
+  });
+
+  const uploadMutation = useMutation({
+    mutationFn: ({ key, file }: { key: TemplateKey; file: File }) => mockApi.uploadTemplate({ key, file }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['templates'] });
+      toast({ title: 'Template uploaded', description: 'Remember to set it active once you are ready.' });
+    },
+    onError: () => {
+      toast({ title: 'Upload failed', description: 'We could not store that file just now.', variant: 'destructive' });
+    },
+    onSettled: () => {
+      setPendingFile(null);
+      setIsConfirmOpen(false);
+    },
+  });
+
+  const activateMutation = useMutation({
+    mutationFn: (id: string) => mockApi.setActiveTemplate(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['templates'] });
+      toast({ title: 'Template set active', description: 'Future documents will reference this file.' });
+    },
+    onError: () => {
+      toast({ title: 'Action failed', description: 'Unable to update the active template.', variant: 'destructive' });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => mockApi.deleteTemplate(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['templates'] });
+      toast({ title: 'Template removed', description: 'You can upload a fresh copy at any time.' });
+    },
+    onError: () => {
+      toast({ title: 'Delete failed', description: 'The template could not be removed.', variant: 'destructive' });
+    },
+  });
+
+  const filteredTemplates = useMemo(() => {
+    if (filter === 'all') return templates;
+    const option = TEMPLATE_OPTIONS.find(item => item.value === filter);
+    if (!option) return templates;
+    return templates.filter(template => template.key === option.key);
+  }, [templates, filter]);
+
+  const selectedKey = useMemo(() => {
+    if (filter === 'all') return null;
+    const option = TEMPLATE_OPTIONS.find(item => item.value === filter);
+    return option?.key ?? null;
+  }, [filter]);
+
+  const handleSelectFile = () => {
+    if (!selectedKey) {
+      toast({ title: 'Choose a document type', description: 'Select a document type before uploading a template.', variant: 'destructive' });
+      return;
+    }
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (!ACCEPTED_TYPES.includes(file.type)) {
+      toast({ title: 'Unsupported file', description: 'Upload a PDF or DOCX template.', variant: 'destructive' });
+      event.target.value = '';
+      return;
+    }
+
+    setPendingFile(file);
+    setIsConfirmOpen(true);
+    event.target.value = '';
+  };
+
+  const confirmUpload = () => {
+    if (!pendingFile || !selectedKey) return;
+    uploadMutation.mutate({ key: selectedKey, file: pendingFile });
+  };
+
+  const renderTable = () => {
+    if (isLoading) {
+      return (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <Skeleton key={index} className="h-12 w-full" />
+          ))}
+        </div>
+      );
+    }
+
+    if (filteredTemplates.length === 0) {
+      return (
+        <div className="rounded-lg border border-dashed py-12 text-center text-sm text-muted-foreground">
+          No templates uploaded for this document yet.
+        </div>
+      );
+    }
+
+    return (
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Document</TableHead>
+              <TableHead>File</TableHead>
+              <TableHead>Size</TableHead>
+              <TableHead>Uploaded</TableHead>
+              <TableHead>Active</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredTemplates.map((template) => (
+              <TableRow key={template.id}>
+                <TableCell>{TEMPLATE_LABELS[template.key] ?? template.key}</TableCell>
+                <TableCell className="max-w-[280px] truncate font-mono text-xs">{template.fileName}</TableCell>
+                <TableCell>{formatBytes(template.sizeBytes)}</TableCell>
+                <TableCell>{new Date(template.uploaded_at).toLocaleString('en-GB')}</TableCell>
+                <TableCell>
+                  {template.active ? (
+                    <Badge className="bg-[var(--brand-primary)] text-[color:var(--brand-primary-contrast)]">
+                      <Check className="mr-1 h-3.5 w-3.5" /> Active
+                    </Badge>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">Inactive</span>
+                  )}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex items-center justify-end gap-2">
+                    {!template.active && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => activateMutation.mutate(template.id)}
+                        disabled={activateMutation.isPending}
+                      >
+                        Set active
+                      </Button>
+                    )}
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => downloadDataUrl(template.fileName, template.dataUrl)}
+                    >
+                      <Download className="h-4 w-4" />
+                      <span className="sr-only">Download template</span>
+                    </Button>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button size="icon" variant="ghost" className="text-destructive">
+                          <Trash2 className="h-4 w-4" />
+                          <span className="sr-only">Delete template</span>
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Delete template</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            This will remove {template.fileName}. You can re-upload it later if needed.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                            onClick={() => deleteMutation.mutate(template.id)}
+                          >
+                            Delete
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    );
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Templates</CardTitle>
+        <CardDescription>Upload official document templates to reference in future exports.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex w-full flex-col gap-2 lg:w-72">
+            <label className="text-sm font-medium">Document type</label>
+            <Select value={filter} onValueChange={value => setFilter(value as TemplateFilterValue)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select a document" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All documents</SelectItem>
+                {TEMPLATE_OPTIONS.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex w-full items-center justify-end gap-3">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".pdf,.doc,.docx,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+              className="hidden"
+              onChange={handleFileChange}
+            />
+            <Button onClick={handleSelectFile} className="w-full lg:w-auto">
+              <CloudUpload className="mr-2 h-4 w-4" />
+              Upload template
+            </Button>
+          </div>
+        </div>
+
+        {renderTable()}
+
+        <p className="text-xs text-muted-foreground">
+          Accepted files: PDF, DOC, DOCX. Active templates are highlighted in document workflows.
+        </p>
+      </CardContent>
+
+      <AlertDialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Use this template?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingFile ? `${pendingFile.name} (${formatBytes(pendingFile.size)})` : 'Select a template to continue.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setPendingFile(null)}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmUpload} disabled={uploadMutation.isPending}>
+              {uploadMutation.isPending ? 'Uploading…' : 'Upload'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+};

--- a/src/features/settings/components/WorkspaceSettingsTab.tsx
+++ b/src/features/settings/components/WorkspaceSettingsTab.tsx
@@ -1,0 +1,201 @@
+import { useRef, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
+import { mockApi } from '@/mocks/api';
+import { useToast } from '@/hooks/use-toast';
+import { downloadDataUrl } from '@/utils/download';
+import { FileDown, FileUp, RotateCcw, Trash2 } from 'lucide-react';
+
+export const WorkspaceSettingsTab = () => {
+  const { toast } = useToast();
+  const importInputRef = useRef<HTMLInputElement>(null);
+  const [importFile, setImportFile] = useState<File | null>(null);
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
+
+  const handleExport = async () => {
+    try {
+      setIsExporting(true);
+      const result = await mockApi.exportWorkspace();
+      downloadDataUrl(result.fileName, result.dataUrl);
+      toast({ title: 'Workspace exported', description: 'A JSON snapshot has been downloaded.' });
+    } catch (error) {
+      console.error(error);
+      toast({ title: 'Export failed', description: 'Unable to export data at the moment.', variant: 'destructive' });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleImportSelect = () => {
+    importInputRef.current?.click();
+  };
+
+  const onImportFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setImportFile(file);
+    setImportDialogOpen(true);
+    event.target.value = '';
+  };
+
+  const confirmImport = async () => {
+    if (!importFile) return;
+    try {
+      setIsImporting(true);
+      await mockApi.importWorkspace(importFile);
+      toast({ title: 'Workspace imported', description: 'Reloading with the imported data.' });
+      setTimeout(() => window.location.reload(), 600);
+    } catch (error) {
+      console.error(error);
+      toast({ title: 'Import failed', description: 'Check the file and try again.', variant: 'destructive' });
+    } finally {
+      setIsImporting(false);
+      setImportDialogOpen(false);
+      setImportFile(null);
+    }
+  };
+
+  const handleResetDemo = async () => {
+    try {
+      setIsResetting(true);
+      await mockApi.resetDemo();
+      toast({ title: 'Demo data restored', description: 'The workspace will now refresh.' });
+      setTimeout(() => window.location.reload(), 600);
+    } catch (error) {
+      console.error(error);
+      toast({ title: 'Reset failed', description: 'We could not reset the demo content.', variant: 'destructive' });
+    } finally {
+      setIsResetting(false);
+    }
+  };
+
+  const handleClearStorage = () => {
+    mockApi.clearStorage();
+    toast({ title: 'Storage cleared', description: 'Reloading to apply the clean slate.' });
+    setTimeout(() => window.location.reload(), 500);
+  };
+
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Export workspace</CardTitle>
+          <CardDescription>Download a JSON snapshot of all demo data.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            The export contains every <code className="rounded bg-muted px-1 py-0.5">prolist_mvp_*</code> entry so you can back up your session.
+          </p>
+          <Button onClick={handleExport} disabled={isExporting} className="w-full md:w-auto">
+            <FileDown className="mr-2 h-4 w-4" />
+            {isExporting ? 'Preparing…' : 'Download workspace JSON'}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Import workspace</CardTitle>
+          <CardDescription>Replace current storage with a JSON export.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            This will overwrite local data. Keep a backup before importing.
+          </p>
+          <input ref={importInputRef} type="file" accept="application/json,.json" className="hidden" onChange={onImportFileChange} />
+          <Button onClick={handleImportSelect} className="w-full md:w-auto">
+            <FileUp className="mr-2 h-4 w-4" />
+            Select JSON file
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Reset demo data</CardTitle>
+          <CardDescription>Restore the baseline dataset provided with ProList.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            All shipments, templates, and settings will be replaced with the original demo seed.
+          </p>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="outline" className="w-full md:w-auto" disabled={isResetting}>
+                <RotateCcw className={`mr-2 h-4 w-4 ${isResetting ? 'animate-spin' : ''}`} />
+                {isResetting ? 'Resetting…' : 'Reset demo'}
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Reset demo data?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This action replaces all current data with the original sample workspace. Continue?
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={handleResetDemo} disabled={isResetting}>
+                  Confirm reset
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </CardContent>
+      </Card>
+
+      <Card className="border-destructive/40">
+        <CardHeader>
+          <CardTitle>Clear storage</CardTitle>
+          <CardDescription>Remove every saved item and reload the workspace.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            This is irreversible. Only use when you want to start again from a clean state.
+          </p>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="destructive" className="w-full md:w-auto">
+                <Trash2 className="mr-2 h-4 w-4" />
+                Clear storage
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Clear all demo data?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  All ProList demo entries will be removed immediately. You will need to import or reset to continue.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={handleClearStorage}>Confirm clear</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </CardContent>
+      </Card>
+
+      <AlertDialog open={importDialogOpen} onOpenChange={setImportDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Import workspace data?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {importFile ? `${importFile.name} (${(importFile.size / 1024).toFixed(1)} KB)` : 'Select a JSON export to continue.'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setImportFile(null)}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmImport} disabled={isImporting}>
+              {isImporting ? 'Importing…' : 'Import and reload'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+};

--- a/src/index.css
+++ b/src/index.css
@@ -20,12 +20,19 @@ All colors MUST be HSL. Brand palette: primary(#048ABF), blue(#049DBF), teal(#03
     --popover-foreground: 210 15% 12%;
 
     /* Brand Primary - ProList Blue #048ABF */
+    --brand-primary: #048abf;
+    --brand-primary-hover: hsl(199 95% 32%);
+    --brand-primary-contrast: #ffffff;
     --primary: 199 95% 38%;
     --primary-foreground: 0 0% 100%;
     --primary-hover: 199 95% 32%;
     --primary-light: 199 95% 95%;
 
     /* Brand Accents */
+    --brand-blue: #049dbf;
+    --brand-teal: #03a6a6;
+    --brand-green: #0aa66d;
+    --brand-mint: #0fbf6d;
     --accent-blue: 195 95% 40%;
     --accent-teal: 180 95% 33%;
     --accent-green: 150 85% 35%;
@@ -88,12 +95,19 @@ All colors MUST be HSL. Brand palette: primary(#048ABF), blue(#049DBF), teal(#03
     --popover-foreground: 210 10% 95%;
 
     /* Brand Primary - Lighter in dark mode */
+    --brand-primary: #048abf;
+    --brand-primary-hover: hsl(199 95% 60%);
+    --brand-primary-contrast: #ffffff;
     --primary: 199 95% 55%;
     --primary-foreground: 210 25% 8%;
     --primary-hover: 199 95% 60%;
     --primary-light: 199 95% 15%;
 
     /* Brand Accents - Adjusted for dark mode */
+    --brand-blue: #049dbf;
+    --brand-teal: #03a6a6;
+    --brand-green: #0aa66d;
+    --brand-mint: #0fbf6d;
     --accent-blue: 195 95% 55%;
     --accent-teal: 180 95% 45%;
     --accent-green: 150 85% 50%;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,8 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { ensureInitialBrandApplied } from "@/utils/theme";
+
+ensureInitialBrandApplied();
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/mocks/seeds.ts
+++ b/src/mocks/seeds.ts
@@ -7,6 +7,7 @@ export interface User {
   email: string;
   name: string;
   role: 'exporter_admin' | 'broker' | 'finance' | 'viewer';
+  created_at: string;
 }
 
 export interface Shipment {
@@ -96,23 +97,26 @@ export interface ShipmentWithItems extends Shipment {
 
 // Seed users
 export const seedUsers: User[] = [
-  { 
-    id: 'u_1', 
-    email: 'jam@prolist.example', 
-    name: 'Jam Ransom', 
-    role: 'exporter_admin' 
+  {
+    id: 'u_1',
+    email: 'jam@prolist.example',
+    name: 'Jam Ransom',
+    role: 'exporter_admin',
+    created_at: '2025-01-04T08:30:00.000Z'
   },
-  { 
-    id: 'u_2', 
-    email: 'broker@prolist.example', 
-    name: 'Alex Broker', 
-    role: 'broker' 
+  {
+    id: 'u_2',
+    email: 'broker@prolist.example',
+    name: 'Alex Broker',
+    role: 'broker',
+    created_at: '2025-02-18T10:15:00.000Z'
   },
-  { 
-    id: 'u_3', 
-    email: 'finance@prolist.example', 
-    name: 'Sam Finance', 
-    role: 'finance' 
+  {
+    id: 'u_3',
+    email: 'finance@prolist.example',
+    name: 'Sam Finance',
+    role: 'finance',
+    created_at: '2025-03-02T14:45:00.000Z'
   },
 ];
 

--- a/src/mocks/types.ts
+++ b/src/mocks/types.ts
@@ -1,6 +1,7 @@
 // Extended types for ProList Issues and Timeline functionality
 
 import type { DocKey } from '@/utils/rules';
+import type { User } from './seeds';
 
 // Re-export existing types from seeds for convenience
 export type { User, Shipment, Product, Partner, ShipmentWithItems, ShipmentItem, ShipmentDocument, DocVersion, DocStatus, Company, HsCode, SavedHsRate } from './seeds';
@@ -89,4 +90,46 @@ export interface Event {
   at: string;
   by?: string; // user id
   payload?: Record<string, unknown>;
+}
+
+export interface OrgSettings {
+  name: string;
+  email?: string;
+  phone?: string;
+  tax_id?: string;
+  country?: string;
+  city?: string;
+  address?: string;
+  logoDataUrl?: string;
+}
+
+export interface BrandSettings {
+  primary: string;
+  accentBlue: string;
+  accentTeal: string;
+  accentGreen: string;
+  accentMint: string;
+}
+
+export type TemplateKey = DocKey;
+
+export interface TemplateMeta {
+  id: string;
+  key: TemplateKey;
+  fileName: string;
+  sizeBytes: number;
+  uploaded_at: string;
+  uploaded_by: string;
+  dataUrl: string;
+  active: boolean;
+}
+
+export type AppRole = User['role'];
+
+export interface AppUserSummary {
+  id: string;
+  name: string;
+  email: string;
+  role: AppRole;
+  created_at: string;
 }

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,0 +1,9 @@
+export function downloadDataUrl(fileName: string, dataUrl: string) {
+  const anchor = document.createElement('a');
+  anchor.href = dataUrl;
+  anchor.download = fileName;
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,0 +1,8 @@
+export async function fileToDataUrl(file: File): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}

--- a/src/utils/rules.ts
+++ b/src/utils/rules.ts
@@ -2,7 +2,14 @@
 
 import type { ShipmentWithItems, Product } from '@/mocks/seeds';
 
-export type DocKey = 'COO' | 'PHYTO' | 'INSURANCE' | 'INVOICE' | 'PACKING_LIST';
+export type DocKey =
+  | 'COO'
+  | 'PHYTO'
+  | 'INSURANCE'
+  | 'INVOICE'
+  | 'PACKING_LIST'
+  | 'BILL_OF_LADING'
+  | 'CUSTOMS_EXPORT_DECLARATION';
 
 export interface DocumentRequirement {
   required: DocKey[];

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,159 @@
+import type { BrandSettings } from "@/mocks/types";
+import { getFromStorage } from "@/utils/storage";
+
+const STORAGE_KEY = "brand_settings";
+
+type HslTuple = {
+  h: number;
+  s: number;
+  l: number;
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const hexToRgb = (hex: string): { r: number; g: number; b: number } | null => {
+  const normalised = hex.replace("#", "");
+  if (!(normalised.length === 6 || normalised.length === 3)) {
+    return null;
+  }
+
+  const full = normalised.length === 3
+    ? normalised.split("").map(ch => ch + ch).join("")
+    : normalised;
+
+  const r = Number.parseInt(full.slice(0, 2), 16);
+  const g = Number.parseInt(full.slice(2, 4), 16);
+  const b = Number.parseInt(full.slice(4, 6), 16);
+
+  if ([r, g, b].some(v => Number.isNaN(v))) {
+    return null;
+  }
+
+  return { r, g, b };
+};
+
+const rgbToHsl = (rgb: { r: number; g: number; b: number }): HslTuple => {
+  const r = rgb.r / 255;
+  const g = rgb.g / 255;
+  const b = rgb.b / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+
+  let h = 0;
+  if (delta !== 0) {
+    switch (max) {
+      case r:
+        h = ((g - b) / delta) % 6;
+        break;
+      case g:
+        h = (b - r) / delta + 2;
+        break;
+      default:
+        h = (r - g) / delta + 4;
+        break;
+    }
+  }
+
+  h = Math.round(h * 60);
+  if (h < 0) {
+    h += 360;
+  }
+
+  const l = (max + min) / 2;
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+
+  return {
+    h,
+    s: Math.round(s * 100),
+    l: Math.round(l * 100),
+  };
+};
+
+const hexToHsl = (hex: string): HslTuple | null => {
+  const rgb = hexToRgb(hex);
+  if (!rgb) return null;
+  return rgbToHsl(rgb);
+};
+
+const hslTupleToString = (tuple: HslTuple): string => `${tuple.h} ${tuple.s}% ${tuple.l}%`;
+
+const determineForeground = (tuple: HslTuple): string => {
+  // Relative luminance approximation using lightness as heuristic
+  return tuple.l > 60 ? "0 0% 12%" : "0 0% 100%";
+};
+
+const adjustLightness = (tuple: HslTuple, amount: number): string => {
+  const adjusted = { ...tuple, l: clamp(tuple.l + amount, 0, 98) };
+  return hslTupleToString(adjusted);
+};
+
+const setCssVar = (name: string, value: string) => {
+  document.documentElement.style.setProperty(name, value);
+};
+
+export function applyBrandToCssVars(brand: BrandSettings) {
+  const entries: Array<[string, string]> = [
+    ["--brand-primary", brand.primary],
+    ["--brand-blue", brand.accentBlue],
+    ["--brand-teal", brand.accentTeal],
+    ["--brand-green", brand.accentGreen],
+    ["--brand-mint", brand.accentMint],
+  ];
+
+  entries.forEach(([name, value]) => setCssVar(name, value));
+
+  const primaryHsl = hexToHsl(brand.primary);
+  if (primaryHsl) {
+    const base = hslTupleToString(primaryHsl);
+    setCssVar("--primary", base);
+    setCssVar("--ring", base);
+    setCssVar("--sidebar-primary", base);
+
+    const hover = adjustLightness(primaryHsl, -8);
+    const light = adjustLightness(primaryHsl, 35);
+
+    setCssVar("--primary-hover", hover);
+    setCssVar("--primary-light", light);
+    setCssVar("--primary-foreground", determineForeground(primaryHsl));
+    setCssVar("--sidebar-ring", base);
+
+    const contrast = determineForeground(primaryHsl) === "0 0% 12%" ? "#111827" : "#FFFFFF";
+    setCssVar("--brand-primary-contrast", contrast);
+    setCssVar("--brand-primary-hover", `hsl(${hover})`);
+  }
+
+  const accentMap: Array<[string, string]> = [
+    ["--accent-blue", brand.accentBlue],
+    ["--accent-teal", brand.accentTeal],
+    ["--accent-green", brand.accentGreen],
+    ["--accent-mint", brand.accentMint],
+  ];
+
+  accentMap.forEach(([name, value]) => {
+    const hsl = hexToHsl(value);
+    if (hsl) {
+      setCssVar(name, hslTupleToString(hsl));
+    }
+  });
+}
+
+export const getInitialBrandSettings = (): BrandSettings => {
+  const stored = getFromStorage<BrandSettings | null>(STORAGE_KEY, null);
+  if (stored) {
+    return stored;
+  }
+  return {
+    primary: "#048ABF",
+    accentBlue: "#049DBF",
+    accentTeal: "#03A6A6",
+    accentGreen: "#0AA66D",
+    accentMint: "#0FBF6D",
+  };
+};
+
+export const ensureInitialBrandApplied = () => {
+  const brand = getInitialBrandSettings();
+  applyBrandToCssVars(brand);
+};


### PR DESCRIPTION
## Summary
- build the settings workspace with Organisation, Branding, Templates, Roles & Users, and Workspace tabs backed by the mock API and local storage
- introduce theme helpers and defaults so saved branding colours apply immediately across the app and on load
- extend the mock API plus navigation/documents to surface organisation logos, template actions, user role updates, and workspace import/export flows

## Testing
- npm run lint *(fails: existing eslint errors in untouched UI utility files, documents, and pdf utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68cb583dd0188324bb09a62ae7f9775c