### PR TITLE
Add GitHub Pages base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: "/ProList_Export/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- add a base path configuration for GitHub Pages deployments in `vite.config.ts`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc4fff76fc83248cf1a7690f56c256