### PR TITLE
Fix routing base configuration for GitHub Pages deployment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,7 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
 
 const App = () => {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>
           <Toaster />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,20 +4,24 @@ import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  base: "/ProList_Export/",
-  server: {
-    host: "::",
-    port: 8080,
-    allowedHosts: [".replit.dev"],
-  },
-  preview: {
-    allowedHosts: [".replit.dev"],
-  },
-  plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const base = mode === "development" ? "/" : "/ProList_Export/";
+
+  return {
+    base,
+    server: {
+      host: "::",
+      port: 8080,
+      allowedHosts: [".replit.dev"],
     },
-  },
-}));
+    preview: {
+      allowedHosts: [".replit.dev"],
+    },
+    plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- set the Vite base path dynamically so local development serves from root while production builds target GitHub Pages
- configure the BrowserRouter basename to align client-side routing with the deployed base path

## Testing
- npm run build
- npm run lint *(fails: pre-existing lint errors in unrelated files such as `@typescript-eslint/no-explicit-any` and `@typescript-eslint/no-empty-object-type`)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5e55a11883248b1029a8928b0578