### PR TITLE
Fix Vite build configuration for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import react from '@vitejs/plugin-react-swc'
+import { fileURLToPath, URL } from 'node:url'
 
 // NOTE: If your Pages URL is username.github.io/ProList_Export,
 // keep '/ProList_Export/'. If you deploy to root/custom domain, use '/'.
@@ -8,5 +9,10 @@ export default defineConfig(({ mode }) => {
   return {
     base: isDev ? '/' : '/ProList_Export/',
     plugins: [react()],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+      },
+    },
   }
 })


### PR DESCRIPTION
## Summary
- switch the Vite React plugin to use the already-installed `@vitejs/plugin-react-swc`
- add a Vite alias for `@` so production builds can resolve imports from `src`

## Testing
- npm run build
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc69cb05f88324aef8a1ce8de84918