### PR TITLE
Allow Replit proxy host for Vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,5 +14,9 @@ export default defineConfig(({ mode }) => {
         '@': fileURLToPath(new URL('./src', import.meta.url)),
       },
     },
+    server: {
+      allowedHosts: [/\.janeway\.replit\.dev$/],
+      host: '0.0.0.0',
+    },
   }
 })


### PR DESCRIPTION
## Summary
- configure Vite dev server to accept Replit's janeway proxy subdomains by default
- bind the dev server to 0.0.0.0 so it can respond inside containerized environments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02558ef98832489efa7528ac9eb6e