### PR TITLE
Configure Vite server port from environment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,8 @@ export default defineConfig(({ mode }) => {
     server: {
       allowedHosts: [/\.janeway\.replit\.dev$/],
       host: '0.0.0.0',
+      port: Number(process.env.PORT) || 5000,
+      strictPort: true,
     },
   }
 })


### PR DESCRIPTION
## Summary
- configure the Vite dev server to bind to the port provided by the PORT environment variable, defaulting to 5000
- enable strictPort so the chosen port is respected when running locally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0659748a883248147a8597a401897