### PR TITLE
Fix base path configuration for Vercel deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,12 +2,23 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import { fileURLToPath, URL } from 'node:url'
 
-// NOTE: If your Pages URL is username.github.io/ProList_Export,
-// keep '/ProList_Export/'. If you deploy to root/custom domain, use '/'.
+// Allow overriding the base path through an environment variable so the
+// project can be hosted from a subdirectory when needed (e.g. GitHub Pages).
+// For platforms like Vercel that serve the app from the domain root we keep
+// the default '/' to avoid broken asset links that lead to a blank page.
+const normaliseBase = (value?: string | null) => {
+  if (!value) return '/'
+  const trimmed = value.trim()
+  const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  return withLeading.endsWith('/') ? withLeading : `${withLeading}/`
+}
+
 export default defineConfig(({ mode }) => {
   const isDev = mode === 'development'
+  const base = normaliseBase(process.env.VITE_APP_BASE)
+
   return {
-    base: isDev ? '/' : '/ProList_Export/',
+    base: isDev ? '/' : base,
     plugins: [react()],
     resolve: {
       alias: {


### PR DESCRIPTION
## Summary
- default the production build to use a root base path so Vercel serves assets correctly
- allow overriding the Vite base via `VITE_APP_BASE` and normalize custom values for GitHub Pages-style deployments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d19d8fa8bc8324ad819778195d37b1