### PR TITLE
Add notifications experience

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { ShipmentWizard } from "@/features/shipments/ShipmentWizard";
 import { ShipmentDetailPage } from "@/features/shipments/ShipmentDetailPage";
 import { DocumentsPage } from "@/features/documents/DocumentsPage";
 import { IssuesPage } from "@/features/issues/IssuesPage";
+import { NotificationsPage } from "@/features/notifications/NotificationsPage";
 import NotFound from "@/pages/NotFound";
 
 // Auth store and query client
@@ -113,6 +114,14 @@ const App = () => {
               </ProtectedRoute>
             }>
               <Route index element={<SettingsPage />} />
+            </Route>
+
+            <Route path="/notifications" element={
+              <ProtectedRoute>
+                <AppShell />
+              </ProtectedRoute>
+            }>
+              <Route index element={<NotificationsPage />} />
             </Route>
 
             {/* 404 fallback */}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -27,24 +27,26 @@ import {
   SidebarTrigger,
   useSidebar 
 } from '@/components/ui/sidebar';
-import { 
-  LayoutDashboard, 
-  Package, 
-  Hash, 
-  FileText, 
-  AlertTriangle, 
-  BarChart3, 
-  Settings, 
+import {
+  LayoutDashboard,
+  Package,
+  Hash,
+  FileText,
+  AlertTriangle,
+  BarChart3,
+  Settings,
   Search,
   User,
   LogOut,
-  Menu
+  Menu,
+  Bell,
 } from 'lucide-react';
 import { useAuthStore } from '@/stores/auth';
 import { NavLink } from 'react-router-dom';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useQuery } from '@tanstack/react-query';
 import { mockApi } from '@/mocks/api';
+import { NotificationsBell } from '@/features/notifications/components/NotificationsBell';
 
 const sidebarItems = [
   { title: 'Dashboard', url: '/app', icon: LayoutDashboard, active: true },
@@ -53,6 +55,7 @@ const sidebarItems = [
   { title: 'Documents', url: '/documents', icon: FileText, disabled: true },
   { title: 'Issues', url: '/issues', icon: AlertTriangle, disabled: true },
   { title: 'Reports', url: '/reports', icon: BarChart3, disabled: false },
+  { title: 'Notifications', url: '/notifications', icon: Bell, disabled: false },
   { title: 'Settings', url: '/settings', icon: Settings, disabled: false },
 ];
 
@@ -172,45 +175,48 @@ export const AppShell = () => {
             </div>
 
             {/* User Menu */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" className="flex items-center gap-2">
-                  <Avatar className="h-8 w-8">
-                    <AvatarFallback className="bg-primary text-primary-foreground">
-                      {user.name.split(' ').map(n => n[0]).join('')}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="hidden md:block text-left">
-                    <div className="text-sm font-medium">{user.name}</div>
-                    <Badge variant="secondary" className="text-xs">
-                      {user.role.replace('_', ' ')}
-                    </Badge>
-                  </div>
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
-                <DropdownMenuLabel>
-                  <div>
-                    <div>{user.name}</div>
-                    <div className="text-xs text-muted-foreground">{user.email}</div>
-                  </div>
-                </DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem disabled>
-                  <User className="mr-2 h-4 w-4" />
-                  Profile
-                </DropdownMenuItem>
-                <DropdownMenuItem disabled>
-                  <Settings className="mr-2 h-4 w-4" />
-                  Settings
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={handleLogout}>
-                  <LogOut className="mr-2 h-4 w-4" />
-                  Sign out
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <div className="flex items-center gap-2">
+              <NotificationsBell />
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" className="flex items-center gap-2">
+                    <Avatar className="h-8 w-8">
+                      <AvatarFallback className="bg-primary text-primary-foreground">
+                        {user.name.split(' ').map(n => n[0]).join('')}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="hidden md:block text-left">
+                      <div className="text-sm font-medium">{user.name}</div>
+                      <Badge variant="secondary" className="text-xs">
+                        {user.role.replace('_', ' ')}
+                      </Badge>
+                    </div>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-56">
+                  <DropdownMenuLabel>
+                    <div>
+                      <div>{user.name}</div>
+                      <div className="text-xs text-muted-foreground">{user.email}</div>
+                    </div>
+                  </DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem disabled>
+                    <User className="mr-2 h-4 w-4" />
+                    Profile
+                  </DropdownMenuItem>
+                  <DropdownMenuItem disabled>
+                    <Settings className="mr-2 h-4 w-4" />
+                    Settings
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={handleLogout}>
+                    <LogOut className="mr-2 h-4 w-4" />
+                    Sign out
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           </header>
 
           {/* Main Content */}

--- a/src/features/notifications/NotificationsPage.tsx
+++ b/src/features/notifications/NotificationsPage.tsx
@@ -1,0 +1,561 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@/components/ui/toggle-group";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/lib/utils";
+import type { NotificationItem } from "@/mocks/types";
+import {
+  NOTIFICATION_FILTERS,
+  NOTIFICATION_TYPE_META,
+  READ_FILTERS,
+  SEVERITY_FILTERS,
+  TIME_FILTERS,
+  VIEW_MODES,
+  type NotificationFilterKey,
+} from "./constants";
+import {
+  filterNotifications,
+  formatRelativeTime,
+  resolveNotificationDestination,
+  sortNotifications,
+  type NotificationFilterState,
+  type ReadFilterValue,
+  type SeverityFilterValue,
+  type TimeFilterValue,
+} from "./utils";
+import { NotificationCard, NotificationCardAction } from "./components/NotificationCard";
+import { useNotifications } from "./hooks/useNotifications";
+import {
+  ArrowRight,
+  CheckSquare,
+  LayoutGrid,
+  Loader2,
+  Search,
+  Table2,
+  Trash2,
+} from "lucide-react";
+
+const PAGE_SIZE_CARDS = 6;
+const PAGE_SIZE_TABLE = 8;
+
+export const NotificationsPage = () => {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { notifications, isLoading, markRead, deleteNotifications, preferences, isDeleting } =
+    useNotifications();
+
+  const [typeFilter, setTypeFilter] = useState<NotificationFilterKey>("all");
+  const [readFilter, setReadFilter] = useState<ReadFilterValue>("all");
+  const [timeFilter, setTimeFilter] = useState<TimeFilterValue>("any");
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilterValue>("all");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [viewMode, setViewMode] = useState<(typeof VIEW_MODES)[number]["value"]>("cards");
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [isMarkingSelected, setIsMarkingSelected] = useState(false);
+  const [page, setPage] = useState(1);
+
+  const highPriorityTypes = useMemo(
+    () => preferences?.highPriority ?? [],
+    [preferences?.highPriority],
+  );
+
+  const sortedNotifications = useMemo(
+    () => sortNotifications(notifications, highPriorityTypes),
+    [notifications, highPriorityTypes],
+  );
+
+  const filterState = useMemo<NotificationFilterState>(
+    () => ({
+      search: searchTerm,
+      filter: typeFilter,
+      read: readFilter,
+      time: timeFilter,
+      severity: severityFilter,
+    }),
+    [searchTerm, typeFilter, readFilter, timeFilter, severityFilter],
+  );
+
+  const filteredNotifications = useMemo(
+    () => filterNotifications(sortedNotifications, filterState),
+    [sortedNotifications, filterState],
+  );
+
+  const pageSize = viewMode === "cards" ? PAGE_SIZE_CARDS : PAGE_SIZE_TABLE;
+  const totalPages = Math.max(1, Math.ceil(filteredNotifications.length / pageSize));
+  const currentPage = Math.min(page, totalPages);
+  const pageSliceStart = (currentPage - 1) * pageSize;
+  const pageSliceEnd = pageSliceStart + pageSize;
+  const paginatedNotifications = filteredNotifications.slice(pageSliceStart, pageSliceEnd);
+
+  useEffect(() => {
+    setPage(1);
+  }, [typeFilter, readFilter, timeFilter, severityFilter, searchTerm, viewMode]);
+
+  useEffect(() => {
+    setSelectedIds(previous =>
+      previous.filter(id => filteredNotifications.some(notification => notification.id === id)),
+    );
+  }, [filteredNotifications]);
+
+  const toggleSelect = (notification: NotificationItem) => {
+    setSelectedIds(previous =>
+      previous.includes(notification.id)
+        ? previous.filter(id => id !== notification.id)
+        : [...previous, notification.id],
+    );
+  };
+
+  const toggleSelectPage = () => {
+    const pageIds = paginatedNotifications.map(notification => notification.id);
+    const hasAll = pageIds.every(id => selectedIds.includes(id));
+
+    setSelectedIds(previous => {
+      if (hasAll) {
+        return previous.filter(id => !pageIds.includes(id));
+      }
+      const merged = new Set([...previous, ...pageIds]);
+      return Array.from(merged);
+    });
+  };
+
+  const handleMarkSelected = async () => {
+    if (!selectedIds.length) return;
+    setIsMarkingSelected(true);
+    try {
+      await Promise.all(selectedIds.map(id => markRead({ id, read: true })));
+      toast({
+        title: "Marked as read",
+        description: `${selectedIds.length} notification${selectedIds.length > 1 ? "s" : ""} updated.`,
+      });
+      setSelectedIds([]);
+    } finally {
+      setIsMarkingSelected(false);
+    }
+  };
+
+  const handleDeleteSelected = async () => {
+    if (!selectedIds.length) return;
+    await deleteNotifications(selectedIds);
+    toast({
+      title: "Notifications removed",
+      description: "The selected updates won’t appear in your feed anymore.",
+    });
+    setSelectedIds([]);
+    setDeleteDialogOpen(false);
+  };
+
+  const handleOpenNotification = async (notification: NotificationItem) => {
+    if (notification.unread) {
+      await markRead({ id: notification.id, read: true });
+    }
+    const destination = resolveNotificationDestination(notification);
+    if (destination) {
+      navigate(destination);
+    } else {
+      toast({
+        title: "Workspace link coming soon",
+        description: "We’ll open this notification in its workspace shortly.",
+      });
+    }
+  };
+
+  const handleViewPreferences = () => {
+    navigate("/settings?tab=notifications");
+  };
+
+  const startItem = filteredNotifications.length === 0 ? 0 : pageSliceStart + 1;
+  const endItem = Math.min(filteredNotifications.length, pageSliceEnd);
+  const allSelectedOnPage =
+    paginatedNotifications.length > 0 &&
+    paginatedNotifications.every(notification => selectedIds.includes(notification.id));
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="text-3xl font-bold">Notifications</h1>
+            <p className="text-muted-foreground">
+              Review and manage updates across your workspace.
+            </p>
+          </div>
+          <Button variant="outline" onClick={handleViewPreferences}>
+            Tune preferences
+          </Button>
+        </div>
+        <div className="text-sm text-muted-foreground">
+          {filteredNotifications.length} notifications · {selectedIds.length} selected
+        </div>
+      </header>
+
+      <section className="rounded-2xl border bg-card/80 p-4 shadow-sm">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="relative w-full lg:max-w-md">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={searchTerm}
+                onChange={event => setSearchTerm(event.target.value)}
+                placeholder="Search by title or reference"
+                className="pl-9"
+              />
+            </div>
+            <ToggleGroup
+              type="single"
+              value={viewMode}
+              onValueChange={value => value && setViewMode(value as (typeof VIEW_MODES)[number]["value"])}
+              className="self-start rounded-full border bg-background/80 p-1"
+            >
+              <ToggleGroupItem
+                value="cards"
+                className="rounded-full px-3 py-1 text-sm data-[state=on]:bg-primary/10 data-[state=on]:text-primary"
+              >
+                <LayoutGrid className="mr-2 h-4 w-4" /> Cards
+              </ToggleGroupItem>
+              <ToggleGroupItem
+                value="table"
+                className="rounded-full px-3 py-1 text-sm data-[state=on]:bg-primary/10 data-[state=on]:text-primary"
+              >
+                <Table2 className="mr-2 h-4 w-4" /> Table
+              </ToggleGroupItem>
+            </ToggleGroup>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <Select value={typeFilter} onValueChange={value => setTypeFilter(value as NotificationFilterKey)}>
+              <SelectTrigger className="rounded-xl border-muted bg-background/80">
+                <SelectValue placeholder="Type" />
+              </SelectTrigger>
+              <SelectContent>
+                {NOTIFICATION_FILTERS.map(filter => (
+                  <SelectItem key={filter.key} value={filter.key}>
+                    {filter.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select value={readFilter} onValueChange={value => setReadFilter(value as ReadFilterValue)}>
+              <SelectTrigger className="rounded-xl border-muted bg-background/80">
+                <SelectValue placeholder="Read status" />
+              </SelectTrigger>
+              <SelectContent>
+                {READ_FILTERS.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select value={timeFilter} onValueChange={value => setTimeFilter(value as TimeFilterValue)}>
+              <SelectTrigger className="rounded-xl border-muted bg-background/80">
+                <SelectValue placeholder="Time" />
+              </SelectTrigger>
+              <SelectContent>
+                {TIME_FILTERS.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select value={severityFilter} onValueChange={value => setSeverityFilter(value as SeverityFilterValue)}>
+              <SelectTrigger className="rounded-xl border-muted bg-background/80">
+                <SelectValue placeholder="Severity" />
+              </SelectTrigger>
+              <SelectContent>
+                {SEVERITY_FILTERS.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={toggleSelectPage}
+              disabled={paginatedNotifications.length === 0}
+            >
+              <CheckSquare className="mr-2 h-4 w-4" />
+              {allSelectedOnPage ? "Clear page" : "Select page"}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleMarkSelected}
+              disabled={!selectedIds.length || isMarkingSelected}
+            >
+              {isMarkingSelected ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <ArrowRight className="mr-2 h-4 w-4" />
+              )}
+              Mark selected as read
+            </Button>
+            <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-destructive hover:text-destructive"
+                  disabled={!selectedIds.length || isDeleting}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" /> Delete selected
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Delete notifications?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    We’ll remove {selectedIds.length} notification
+                    {selectedIds.length === 1 ? "" : "s"}. This action can’t be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleDeleteSelected} disabled={isDeleting}>
+                    {isDeleting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                    Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        {isLoading ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Card key={`loading-${index}`} className="rounded-2xl border bg-card/70">
+                <CardContent className="space-y-3 p-5">
+                  <Skeleton className="h-4 w-2/3" />
+                  <Skeleton className="h-3 w-5/6" />
+                  <Skeleton className="h-3 w-1/2" />
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : filteredNotifications.length === 0 ? (
+          <Card className="rounded-2xl border-dashed bg-muted/40">
+            <CardContent className="flex flex-col items-center justify-center space-y-2 p-10 text-center">
+              <h3 className="text-lg font-semibold">All clear for now</h3>
+              <p className="text-sm text-muted-foreground">
+                Adjust your filters or check back later for new activity.
+              </p>
+            </CardContent>
+          </Card>
+        ) : viewMode === "cards" ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            {paginatedNotifications.map(notification => (
+              <NotificationCard
+                key={notification.id}
+                notification={notification}
+                highPriority={notification.unread && highPriorityTypes.includes(notification.type)}
+                onClick={() => handleOpenNotification(notification)}
+                padding="comfortable"
+                selectionControl={
+                  <Checkbox
+                    checked={selectedIds.includes(notification.id)}
+                    onCheckedChange={() => toggleSelect(notification)}
+                  />
+                }
+                actionSlot={
+                  <NotificationCardAction onClick={() => handleOpenNotification(notification)}>
+                    Go to
+                  </NotificationCardAction>
+                }
+              />
+            ))}
+          </div>
+        ) : (
+          <Card className="rounded-2xl border bg-card/80">
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-b">
+                    <TableHead className="w-12">
+                      <Checkbox checked={allSelectedOnPage} onCheckedChange={toggleSelectPage} />
+                    </TableHead>
+                    <TableHead className="min-w-[120px]">Type</TableHead>
+                    <TableHead>Title</TableHead>
+                    <TableHead>Context</TableHead>
+                    <TableHead className="w-[120px]">Time</TableHead>
+                    <TableHead className="w-[90px]">Status</TableHead>
+                    <TableHead className="w-[110px]">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {paginatedNotifications.map(notification => {
+                    const typeMeta = NOTIFICATION_TYPE_META[notification.type];
+                    const isSelected = selectedIds.includes(notification.id);
+                    const highPriority = notification.unread && highPriorityTypes.includes(notification.type);
+
+                    return (
+                      <TableRow
+                        key={notification.id}
+                        className={cn(
+                          notification.unread ? "bg-muted/40" : "",
+                          isSelected && "ring-1 ring-primary/40",
+                        )}
+                      >
+                        <TableCell>
+                          <Checkbox
+                            checked={isSelected}
+                            onCheckedChange={() => toggleSelect(notification)}
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <span
+                            className={cn(
+                              "inline-flex items-center gap-2 rounded-full px-2 py-1 text-xs font-medium",
+                              typeMeta.badgeClass,
+                            )}
+                          >
+                            <typeMeta.icon className="h-3.5 w-3.5" />
+                            {typeMeta.label}
+                          </span>
+                        </TableCell>
+                        <TableCell className="font-medium text-foreground">
+                          {notification.title}
+                          {highPriority ? (
+                            <Badge variant="destructive" className="ml-2 rounded-full text-[10px] uppercase">
+                              High priority
+                            </Badge>
+                          ) : null}
+                        </TableCell>
+                        <TableCell className="max-w-[280px] text-sm text-muted-foreground">
+                          {notification.context}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {formatRelativeTime(notification.occurredAt)}
+                        </TableCell>
+                        <TableCell>
+                          {notification.unread ? (
+                            <Badge variant="secondary" className="rounded-full text-[10px] uppercase">
+                              New
+                            </Badge>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">Read</span>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-primary"
+                            onClick={() => handleOpenNotification(notification)}
+                          >
+                            Open <ArrowRight className="ml-1 h-4 w-4" />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+        )}
+      </section>
+
+      <div className="flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-sm text-muted-foreground">
+          Showing {startItem}-{endItem} of {filteredNotifications.length} updates
+        </div>
+        <Pagination>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious
+                href="#"
+                onClick={event => {
+                  event.preventDefault();
+                  setPage(currentPage === 1 ? currentPage : currentPage - 1);
+                }}
+                className={cn(currentPage === 1 && "pointer-events-none opacity-50")}
+              />
+            </PaginationItem>
+            {Array.from({ length: totalPages }).map((_, index) => {
+              const pageNumber = index + 1;
+              return (
+                <PaginationItem key={`page-${pageNumber}`}>
+                  <PaginationLink
+                    href="#"
+                    isActive={pageNumber === currentPage}
+                    onClick={event => {
+                      event.preventDefault();
+                      setPage(pageNumber);
+                    }}
+                  >
+                    {pageNumber}
+                  </PaginationLink>
+                </PaginationItem>
+              );
+            })}
+            <PaginationItem>
+              <PaginationNext
+                href="#"
+                onClick={event => {
+                  event.preventDefault();
+                  setPage(currentPage === totalPages ? currentPage : currentPage + 1);
+                }}
+                className={cn(currentPage === totalPages && "pointer-events-none opacity-50")}
+              />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+      </div>
+    </div>
+  );
+};

--- a/src/features/notifications/components/NotificationCard.tsx
+++ b/src/features/notifications/components/NotificationCard.tsx
@@ -1,0 +1,181 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { NotificationItem, NotificationType } from "@/mocks/types";
+import { NOTIFICATION_TYPE_META } from "../constants";
+import { formatRelativeTime, getSeverityBadgeVariant } from "../utils";
+
+interface NotificationCardProps {
+  notification: NotificationItem;
+  highPriority?: boolean;
+  onClick?: () => void;
+  actionSlot?: React.ReactNode;
+  selectionControl?: React.ReactNode;
+  padding?: "compact" | "comfortable";
+}
+
+const renderDigestEntry = (
+  notificationId: string,
+  type: NotificationType,
+  label: string,
+  value: string,
+) => {
+  const meta = NOTIFICATION_TYPE_META[type];
+  const Icon = meta.icon;
+
+  return (
+    <span
+      key={`${notificationId}-${type}-${value}`}
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-medium",
+        meta.badgeClass,
+      )}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      <span className="font-medium">{label}:</span> {value}
+    </span>
+  );
+};
+
+export const NotificationCard = ({
+  notification,
+  highPriority = false,
+  onClick,
+  actionSlot,
+  selectionControl,
+  padding = "compact",
+}: NotificationCardProps) => {
+  const meta = NOTIFICATION_TYPE_META[notification.type];
+  const Icon = meta.icon;
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!onClick) return;
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onClick();
+    }
+  };
+
+  return (
+    <div
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      data-unread={notification.unread}
+      className={cn(
+        "group relative flex gap-3 rounded-xl border bg-card/80 text-left shadow-sm transition hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/80",
+        meta.cardTintClass,
+        onClick && "cursor-pointer",
+        padding === "compact" ? "p-3" : "p-4",
+      )}
+    >
+      {selectionControl ? (
+        <div className="pt-1" onClick={event => event.stopPropagation()}>
+          {selectionControl}
+        </div>
+      ) : null}
+
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-muted/70">
+        <Icon className={cn("h-5 w-5", meta.iconClass)} aria-hidden />
+      </div>
+
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="truncate text-sm font-semibold text-foreground">
+                {notification.title}
+              </p>
+              {notification.unread ? (
+                <Badge
+                  variant="secondary"
+                  className="rounded-full bg-muted/80 text-[10px] font-semibold uppercase tracking-wide"
+                >
+                  New
+                </Badge>
+              ) : null}
+              {highPriority && notification.unread ? (
+                <Badge
+                  variant="destructive"
+                  className="uppercase tracking-wide text-[10px]"
+                >
+                  High priority
+                </Badge>
+              ) : null}
+              {notification.metadata?.severity ? (
+                <Badge
+                  variant={getSeverityBadgeVariant(notification.metadata.severity)}
+                  className="capitalize text-[10px]"
+                >
+                  {notification.metadata.severity}
+                </Badge>
+              ) : null}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {notification.context}
+            </p>
+            {notification.metadata?.paymentAmount ? (
+              <p className="text-xs text-muted-foreground">
+                Recorded amount:{" "}
+                <span className="font-medium text-foreground">
+                  {notification.metadata.paymentAmount}
+                </span>
+              </p>
+            ) : null}
+          </div>
+          <span className="whitespace-nowrap text-xs text-muted-foreground">
+            {formatRelativeTime(notification.occurredAt)}
+          </span>
+        </div>
+
+        {notification.metadata?.digestBreakdown?.length ? (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {notification.metadata.digestBreakdown.map(entry =>
+              renderDigestEntry(notification.id, entry.type, entry.label, entry.value),
+            )}
+          </div>
+        ) : null}
+      </div>
+
+      {notification.unread ? (
+        <span
+          className={cn(
+            "absolute right-3 top-3 h-2.5 w-2.5 rounded-full",
+            highPriority ? "bg-destructive" : meta.dotClass,
+          )}
+          aria-hidden
+        />
+      ) : null}
+
+      {actionSlot ? (
+        <div
+          className="shrink-0 self-start"
+          onClick={event => event.stopPropagation()}
+        >
+          {actionSlot}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export const NotificationCardAction = ({
+  children,
+  onClick,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+}) => (
+  <Button
+    variant="outline"
+    size="sm"
+    className="rounded-full"
+    onClick={event => {
+      event.stopPropagation();
+      onClick?.();
+    }}
+  >
+    {children}
+  </Button>
+);

--- a/src/features/notifications/components/NotificationsBell.tsx
+++ b/src/features/notifications/components/NotificationsBell.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetTrigger } from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { BELL_ICON } from "../constants";
+import { useNotifications } from "../hooks/useNotifications";
+import { NotificationsPanel } from "./NotificationsPanel";
+
+export const NotificationsBell = () => {
+  const [open, setOpen] = useState(false);
+  const { unreadCount } = useNotifications();
+  const BellIcon = BELL_ICON;
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="relative rounded-full text-muted-foreground hover:text-foreground"
+        >
+          <BellIcon className="h-5 w-5" />
+          {unreadCount > 0 ? (
+            <span
+              className={cn(
+                "absolute -right-0.5 -top-0.5 flex min-h-[1.1rem] min-w-[1.1rem] items-center justify-center rounded-full bg-destructive px-1 text-[10px] font-semibold text-destructive-foreground shadow-sm",
+                unreadCount > 9 && "px-1.5",
+              )}
+            >
+              {unreadCount > 9 ? "9+" : unreadCount}
+            </span>
+          ) : null}
+        </Button>
+      </SheetTrigger>
+      <NotificationsPanel onClose={() => setOpen(false)} />
+    </Sheet>
+  );
+};

--- a/src/features/notifications/components/NotificationsPanel.tsx
+++ b/src/features/notifications/components/NotificationsPanel.tsx
@@ -1,0 +1,182 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SheetContent } from "@/components/ui/sheet";
+import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/lib/utils";
+import type { NotificationItem } from "@/mocks/types";
+import {
+  NOTIFICATION_FILTERS,
+  type NotificationFilterKey,
+} from "../constants";
+import { NotificationCard } from "./NotificationCard";
+import { useNotifications } from "../hooks/useNotifications";
+import { formatRelativeTime, resolveNotificationDestination, sortNotifications } from "../utils";
+import { CheckCircle2, Loader2, SlidersHorizontal } from "lucide-react";
+
+interface NotificationsPanelProps {
+  onClose: () => void;
+}
+
+export const NotificationsPanel = ({ onClose }: NotificationsPanelProps) => {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { notifications, isLoading, markRead, markAllRead, unreadCount, preferences, isMarkingAll } =
+    useNotifications();
+  const [activeFilter, setActiveFilter] = useState<NotificationFilterKey>("all");
+
+  const highPriorityTypes = useMemo(
+    () => preferences?.highPriority ?? [],
+    [preferences?.highPriority],
+  );
+
+  const sortedNotifications = useMemo(
+    () => sortNotifications(notifications, highPriorityTypes),
+    [notifications, highPriorityTypes],
+  );
+
+  const filtered = useMemo(() => {
+    if (activeFilter === "all") return sortedNotifications;
+    return sortedNotifications.filter(notification => notification.type === activeFilter);
+  }, [sortedNotifications, activeFilter]);
+
+  const lastUpdatedLabel = sortedNotifications.length
+    ? formatRelativeTime(sortedNotifications[0].occurredAt)
+    : 'moments ago';
+
+  const handleItemClick = async (notification: NotificationItem) => {
+    if (notification.unread) {
+      await markRead({ id: notification.id, read: true });
+    }
+
+    const destination = resolveNotificationDestination(notification);
+    if (destination) {
+      navigate(destination);
+    } else {
+      toast({
+        title: "We're saving your place",
+        description: "This notification will open the right workspace soon.",
+      });
+    }
+    onClose();
+  };
+
+  const handleViewAll = () => {
+    navigate("/notifications");
+    onClose();
+  };
+
+  const handleOpenSettings = () => {
+    navigate("/settings?tab=notifications");
+    onClose();
+  };
+
+  const handleMarkAll = async () => {
+    if (unreadCount === 0 || isMarkingAll) return;
+    await markAllRead();
+  };
+
+  return (
+    <SheetContent side="right" className="w-full max-w-full border-l p-0 sm:max-w-lg">
+      <div className="flex h-full flex-col">
+        <header className="flex items-center justify-between border-b px-6 py-4">
+          <div>
+            <h2 className="text-lg font-semibold">Notifications</h2>
+            <p className="text-sm text-muted-foreground">
+              Stay on top of documents, shipments, and issues.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground hover:text-foreground"
+              onClick={handleMarkAll}
+              disabled={unreadCount === 0 || isMarkingAll}
+            >
+              {isMarkingAll ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <CheckCircle2 className="mr-2 h-4 w-4" />
+              )}
+              Mark all as read
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleOpenSettings}>
+              <SlidersHorizontal className="mr-2 h-4 w-4" />
+              Settings
+            </Button>
+          </div>
+        </header>
+
+        <div className="border-b px-4 py-3">
+          <ScrollArea className="max-w-full">
+            <div className="flex w-max gap-2 pr-4">
+              {NOTIFICATION_FILTERS.map(filter => (
+                <button
+                  key={filter.key}
+                  type="button"
+                  onClick={() => setActiveFilter(filter.key)}
+                  className={cn(
+                    "rounded-full px-3 py-1 text-xs font-medium transition",
+                    activeFilter === filter.key
+                      ? "bg-primary/10 text-primary shadow-sm"
+                      : "bg-muted/60 text-muted-foreground hover:bg-muted",
+                  )}
+                >
+                  {filter.label}
+                </button>
+              ))}
+            </div>
+          </ScrollArea>
+        </div>
+
+        <ScrollArea className="flex-1">
+          <div className="space-y-3 px-4 py-4">
+            {isLoading ? (
+              Array.from({ length: 4 }).map((_, index) => (
+                <div
+                  key={`skeleton-${index}`}
+                  className="rounded-xl border bg-muted/30 p-4"
+                >
+                  <Skeleton className="mb-3 h-4 w-3/4" />
+                  <Skeleton className="h-3 w-5/6" />
+                </div>
+              ))
+            ) : filtered.length === 0 ? (
+              <div className="flex flex-col items-center justify-center rounded-xl border border-dashed bg-muted/40 px-6 py-10 text-center">
+                <CheckCircle2 className="mb-3 h-10 w-10 text-muted-foreground" />
+                <p className="text-sm font-medium text-foreground">All caught up.</p>
+                <p className="text-sm text-muted-foreground">
+                  You’ll see updates here as work progresses.
+                </p>
+              </div>
+            ) : (
+              filtered.map(notification => (
+                <NotificationCard
+                  key={notification.id}
+                  notification={notification}
+                  highPriority={notification.unread && highPriorityTypes.includes(notification.type)}
+                  onClick={() => handleItemClick(notification)}
+                  padding="compact"
+                />
+              ))
+            )}
+          </div>
+        </ScrollArea>
+
+        <footer className="border-t px-6 py-4">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>
+              {unreadCount} unread · Last update {lastUpdatedLabel}
+            </span>
+            <Button variant="ghost" size="sm" className="text-primary" onClick={handleViewAll}>
+              View all notifications
+            </Button>
+          </div>
+        </footer>
+      </div>
+    </SheetContent>
+  );
+};

--- a/src/features/notifications/constants.ts
+++ b/src/features/notifications/constants.ts
@@ -1,0 +1,101 @@
+import type { NotificationType } from "@/mocks/types";
+import type { LucideIcon } from "lucide-react";
+import {
+  AlertTriangle,
+  Bell,
+  CreditCard,
+  FileText,
+  Info,
+  Package,
+} from "lucide-react";
+
+export type NotificationFilterKey = "all" | NotificationType;
+
+export interface NotificationTypeMeta {
+  label: string;
+  icon: LucideIcon;
+  badgeClass: string;
+  iconClass: string;
+  cardTintClass: string;
+  dotClass: string;
+}
+
+export const NOTIFICATION_FILTERS: Array<{ key: NotificationFilterKey; label: string }> = [
+  { key: "all", label: "All" },
+  { key: "documents", label: "Documents" },
+  { key: "issues", label: "Issues" },
+  { key: "shipments", label: "Shipments" },
+  { key: "payments", label: "Payments" },
+  { key: "system", label: "System" },
+];
+
+export const NOTIFICATION_TYPE_META: Record<NotificationType, NotificationTypeMeta> = {
+  documents: {
+    label: "Documents",
+    icon: FileText,
+    badgeClass: "bg-teal-50 text-teal-700 dark:bg-teal-950/30 dark:text-teal-300",
+    iconClass: "text-teal-600 dark:text-teal-300",
+    cardTintClass: "data-[unread=true]:bg-teal-50/80 data-[unread=true]:dark:bg-teal-950/20 border-teal-100/80 dark:border-teal-900/40",
+    dotClass: "bg-teal-500",
+  },
+  issues: {
+    label: "Issues",
+    icon: AlertTriangle,
+    badgeClass: "bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-200",
+    iconClass: "text-amber-600 dark:text-amber-300",
+    cardTintClass: "data-[unread=true]:bg-amber-50/70 data-[unread=true]:dark:bg-amber-950/25 border-amber-100/80 dark:border-amber-900/40",
+    dotClass: "bg-red-500",
+  },
+  shipments: {
+    label: "Shipments",
+    icon: Package,
+    badgeClass: "bg-blue-50 text-blue-700 dark:bg-blue-950/30 dark:text-blue-200",
+    iconClass: "text-blue-600 dark:text-blue-300",
+    cardTintClass: "data-[unread=true]:bg-blue-50/70 data-[unread=true]:dark:bg-blue-950/25 border-blue-100/80 dark:border-blue-900/40",
+    dotClass: "bg-blue-500",
+  },
+  payments: {
+    label: "Payments",
+    icon: CreditCard,
+    badgeClass: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-200",
+    iconClass: "text-emerald-600 dark:text-emerald-300",
+    cardTintClass: "data-[unread=true]:bg-emerald-50/70 data-[unread=true]:dark:bg-emerald-950/25 border-emerald-100/80 dark:border-emerald-900/40",
+    dotClass: "bg-emerald-500",
+  },
+  system: {
+    label: "System",
+    icon: Info,
+    badgeClass: "bg-slate-100 text-slate-700 dark:bg-slate-900/70 dark:text-slate-200",
+    iconClass: "text-slate-500 dark:text-slate-300",
+    cardTintClass: "data-[unread=true]:bg-slate-100/70 data-[unread=true]:dark:bg-slate-900/40 border-slate-200/70 dark:border-slate-800/60",
+    dotClass: "bg-slate-400",
+  },
+};
+
+export const READ_FILTERS = [
+  { value: "all", label: "All" },
+  { value: "unread", label: "Unread" },
+  { value: "read", label: "Read" },
+] as const;
+
+export const TIME_FILTERS = [
+  { value: "any", label: "Any time" },
+  { value: "today", label: "Today" },
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+] as const;
+
+export const SEVERITY_FILTERS = [
+  { value: "all", label: "All severities" },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "critical", label: "Critical" },
+] as const;
+
+export const VIEW_MODES = [
+  { value: "cards", label: "Cards" },
+  { value: "table", label: "Table" },
+] as const;
+
+export const BELL_ICON = Bell;

--- a/src/features/notifications/hooks/useNotifications.ts
+++ b/src/features/notifications/hooks/useNotifications.ts
@@ -1,0 +1,73 @@
+import { useMemo } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { mockApi } from "@/mocks/api";
+import type { NotificationItem, NotificationPreferences } from "@/mocks/types";
+
+interface MarkReadPayload {
+  id: string;
+  read: boolean;
+}
+
+export const useNotifications = () => {
+  const queryClient = useQueryClient();
+
+  const notificationsQuery = useQuery<NotificationItem[]>({
+    queryKey: ["notifications"],
+    queryFn: () => mockApi.getNotifications(),
+  });
+
+  const preferencesQuery = useQuery<NotificationPreferences>({
+    queryKey: ["notification-preferences"],
+    queryFn: () => mockApi.getNotificationPreferences(),
+  });
+
+  const markReadMutation = useMutation({
+    mutationFn: ({ id, read }: MarkReadPayload) => mockApi.markNotificationRead(id, read),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    },
+  });
+
+  const markAllMutation = useMutation({
+    mutationFn: () => mockApi.markAllNotificationsRead(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (ids: string[]) => mockApi.deleteNotifications(ids),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    },
+  });
+
+  const updatePreferencesMutation = useMutation({
+    mutationFn: (preferences: NotificationPreferences) => mockApi.updateNotificationPreferences(preferences),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["notification-preferences"] });
+      queryClient.invalidateQueries({ queryKey: ["notifications"] });
+    },
+  });
+
+  const unreadCount = useMemo(
+    () => (notificationsQuery.data ?? []).filter(notification => notification.unread).length,
+    [notificationsQuery.data],
+  );
+
+  return {
+    notifications: notificationsQuery.data ?? [],
+    isLoading: notificationsQuery.isLoading,
+    preferences: preferencesQuery.data,
+    preferencesLoading: preferencesQuery.isLoading,
+    unreadCount,
+    markRead: markReadMutation.mutateAsync,
+    markAllRead: markAllMutation.mutateAsync,
+    deleteNotifications: deleteMutation.mutateAsync,
+    updatePreferences: updatePreferencesMutation.mutateAsync,
+    isMarkingAll: markAllMutation.isPending,
+    isMarking: markReadMutation.isPending,
+    isDeleting: deleteMutation.isPending,
+    isUpdatingPreferences: updatePreferencesMutation.isPending,
+  };
+};

--- a/src/features/notifications/utils.ts
+++ b/src/features/notifications/utils.ts
@@ -1,0 +1,164 @@
+import { differenceInHours, differenceInMinutes, differenceInDays, isToday } from "date-fns";
+import type {
+  IssueSeverity,
+  NotificationItem,
+  NotificationPreferences,
+  NotificationType,
+} from "@/mocks/types";
+import type { NotificationFilterKey } from "./constants";
+
+export type ReadFilterValue = "all" | "read" | "unread";
+export type TimeFilterValue = "any" | "today" | "7d" | "30d";
+export type SeverityFilterValue = "all" | IssueSeverity;
+
+export const formatRelativeTime = (value: string): string => {
+  const date = new Date(value);
+  const minutes = differenceInMinutes(new Date(), date);
+
+  if (minutes < 1) {
+    return "Just now";
+  }
+
+  if (minutes < 60) {
+    return `${minutes} min ago`;
+  }
+
+  const hours = differenceInHours(new Date(), date);
+  if (hours < 24) {
+    return `${hours} hr${hours === 1 ? "" : "s"} ago`;
+  }
+
+  if (isToday(date)) {
+    return "Today";
+  }
+
+  const days = differenceInDays(new Date(), date);
+  if (days < 30) {
+    return `${days} day${days === 1 ? "" : "s"} ago`;
+  }
+
+  return date.toLocaleDateString("en-GB", {
+    day: "2-digit",
+    month: "short",
+  });
+};
+
+export const sortNotifications = (
+  notifications: NotificationItem[],
+  highPriorityTypes: NotificationType[] = [],
+): NotificationItem[] => {
+  return [...notifications].sort((a, b) => {
+    const aPinned = a.unread && highPriorityTypes.includes(a.type);
+    const bPinned = b.unread && highPriorityTypes.includes(b.type);
+
+    if (aPinned && !bPinned) return -1;
+    if (!aPinned && bPinned) return 1;
+
+    return new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime();
+  });
+};
+
+const matchesSearch = (notification: NotificationItem, term: string) => {
+  if (!term) return true;
+  const haystack = `${notification.title} ${notification.context}`.toLowerCase();
+  return haystack.includes(term.toLowerCase());
+};
+
+const matchesType = (notification: NotificationItem, filter: NotificationFilterKey) => {
+  if (filter === "all") return true;
+  return notification.type === filter;
+};
+
+const matchesRead = (notification: NotificationItem, read: ReadFilterValue) => {
+  if (read === "all") return true;
+  if (read === "read") return !notification.unread;
+  return notification.unread;
+};
+
+const matchesTime = (notification: NotificationItem, time: TimeFilterValue) => {
+  if (time === "any") return true;
+
+  const date = new Date(notification.occurredAt);
+
+  if (time === "today") {
+    return isToday(date);
+  }
+
+  if (time === "7d") {
+    const diff = differenceInDays(new Date(), date);
+    return diff <= 7;
+  }
+
+  if (time === "30d") {
+    const diff = differenceInDays(new Date(), date);
+    return diff <= 30;
+  }
+
+  return true;
+};
+
+const matchesSeverity = (notification: NotificationItem, severity: SeverityFilterValue) => {
+  if (severity === "all") return true;
+  return notification.metadata?.severity === severity;
+};
+
+export interface NotificationFilterState {
+  search: string;
+  filter: NotificationFilterKey;
+  read: ReadFilterValue;
+  time: TimeFilterValue;
+  severity: SeverityFilterValue;
+}
+
+export const filterNotifications = (
+  notifications: NotificationItem[],
+  filters: NotificationFilterState,
+): NotificationItem[] => {
+  return notifications.filter(notification =>
+    matchesType(notification, filters.filter) &&
+    matchesRead(notification, filters.read) &&
+    matchesTime(notification, filters.time) &&
+    matchesSeverity(notification, filters.severity) &&
+    matchesSearch(notification, filters.search),
+  );
+};
+
+export const buildQuietHoursLabel = (preferences?: NotificationPreferences) => {
+  if (!preferences) return "";
+  if (!preferences.quietHours.enabled) {
+    return "Quiet hours off";
+  }
+  return `Quiet hours ${preferences.quietHours.start}–${preferences.quietHours.end}`;
+};
+
+export const getSeverityBadgeVariant = (severity?: IssueSeverity) => {
+  switch (severity) {
+    case "critical":
+      return "destructive";
+    case "high":
+      return "default";
+    case "medium":
+      return "secondary";
+    case "low":
+    default:
+      return "outline";
+  }
+};
+
+export const resolveNotificationDestination = (
+  notification: NotificationItem,
+): string | undefined => {
+  const shipmentId = notification.metadata?.shipmentId;
+
+  switch (notification.type) {
+    case "documents":
+    case "payments":
+    case "shipments":
+      return shipmentId ? `/shipments/${shipmentId}` : "/shipments";
+    case "issues":
+      return shipmentId ? `/shipments/${shipmentId}` : "/issues";
+    case "system":
+    default:
+      return "/notifications";
+  }
+};

--- a/src/features/settings/SettingsPage.tsx
+++ b/src/features/settings/SettingsPage.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { OrganisationSettingsTab } from './components/OrganisationSettingsTab';
 import { BrandingSettingsTab } from './components/BrandingSettingsTab';
 import { TemplatesSettingsTab } from './components/TemplatesSettingsTab';
 import { RolesUsersSettingsTab } from './components/RolesUsersSettingsTab';
 import { WorkspaceSettingsTab } from './components/WorkspaceSettingsTab';
+import { NotificationsSettingsTab } from './components/NotificationsSettingsTab';
+import { useSearchParams } from 'react-router-dom';
 
 const SETTINGS_TABS = [
   { value: 'organisation', label: 'Organisation' },
@@ -12,12 +14,29 @@ const SETTINGS_TABS = [
   { value: 'templates', label: 'Templates' },
   { value: 'roles', label: 'Roles & Users' },
   { value: 'workspace', label: 'Workspace' },
+  { value: 'notifications', label: 'Notifications' },
 ] as const;
 
 type SettingsTabValue = (typeof SETTINGS_TABS)[number]['value'];
 
 export const SettingsPage = () => {
-  const [activeTab, setActiveTab] = useState<SettingsTabValue>('organisation');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialTab = useMemo(() => {
+    const param = searchParams.get('tab');
+    return SETTINGS_TABS.some(tab => tab.value === param)
+      ? (param as SettingsTabValue)
+      : 'organisation';
+  }, [searchParams]);
+  const [activeTab, setActiveTab] = useState<SettingsTabValue>(initialTab);
+
+  useEffect(() => {
+    setActiveTab(initialTab);
+  }, [initialTab]);
+
+  const handleTabChange = (value: SettingsTabValue) => {
+    setActiveTab(value);
+    setSearchParams({ tab: value });
+  };
 
   return (
     <div className="space-y-6">
@@ -28,7 +47,7 @@ export const SettingsPage = () => {
         </p>
       </header>
 
-      <Tabs value={activeTab} onValueChange={value => setActiveTab(value as SettingsTabValue)}>
+      <Tabs value={activeTab} onValueChange={value => handleTabChange(value as SettingsTabValue)}>
         <TabsList className="flex flex-wrap justify-start gap-2 rounded-full bg-muted/60 p-1">
           {SETTINGS_TABS.map(tab => (
             <TabsTrigger
@@ -55,6 +74,9 @@ export const SettingsPage = () => {
         </TabsContent>
         <TabsContent value="workspace" className="mt-6">
           <WorkspaceSettingsTab />
+        </TabsContent>
+        <TabsContent value="notifications" className="mt-6">
+          <NotificationsSettingsTab />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/features/settings/components/NotificationsSettingsTab.tsx
+++ b/src/features/settings/components/NotificationsSettingsTab.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useMemo, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/components/ui/use-toast";
+import { cn } from "@/lib/utils";
+import type {
+  NotificationPreferences,
+  NotificationType,
+} from "@/mocks/types";
+import { NOTIFICATION_TYPE_META } from "@/features/notifications/constants";
+import { buildQuietHoursLabel } from "@/features/notifications/utils";
+import { useNotifications } from "@/features/notifications/hooks/useNotifications";
+
+const TYPE_DESCRIPTIONS: Record<NotificationType, string> = {
+  documents: "Generated or approved documents.",
+  issues: "When an issue opens, changes status, or gets a comment.",
+  shipments: "Shipment created, submitted, or cleared events.",
+  payments: "Payments captured against a shipment.",
+  system: "System notices and digest summaries.",
+};
+
+const DIGEST_LABELS = {
+  daily: "Daily",
+  weekly: "Weekly",
+  off: "Off",
+};
+
+export const NotificationsSettingsTab = () => {
+  const { toast } = useToast();
+  const { preferences, preferencesLoading, updatePreferences, isUpdatingPreferences } = useNotifications();
+  const [draft, setDraft] = useState<NotificationPreferences | null>(null);
+
+  useEffect(() => {
+    if (preferences) {
+      setDraft(preferences);
+    }
+  }, [preferences]);
+
+  const enabledTypes = useMemo(
+    () =>
+      draft
+        ? (Object.entries(draft.enabled) as Array<[NotificationType, boolean]>).filter(([, enabled]) => enabled)
+        : [],
+    [draft],
+  );
+
+  const previewLine = useMemo(() => {
+    if (!draft) return "";
+
+    const enabledSummary = enabledTypes
+      .map(([type]) => {
+        const label = NOTIFICATION_TYPE_META[type].label;
+        return draft.highPriority.includes(type) ? `${label} (high)` : label;
+      })
+      .join(", ");
+
+    const digestLabel = draft.digest === "off" ? "Digest off" : `${DIGEST_LABELS[draft.digest]} digest`;
+
+    return [enabledSummary || "No types enabled", digestLabel, buildQuietHoursLabel(draft)].join(" · ");
+  }, [draft, enabledTypes]);
+
+  const toggleType = (type: NotificationType, next: boolean) => {
+    setDraft(current =>
+      current
+        ? {
+            ...current,
+            enabled: {
+              ...current.enabled,
+              [type]: next,
+            },
+            highPriority: next
+              ? current.highPriority
+              : current.highPriority.filter(priorityType => priorityType !== type),
+          }
+        : current,
+    );
+  };
+
+  const toggleHighPriority = (type: NotificationType) => {
+    setDraft(current =>
+      current
+        ? {
+            ...current,
+            highPriority: current.highPriority.includes(type)
+              ? current.highPriority.filter(priorityType => priorityType !== type)
+              : [...current.highPriority, type],
+          }
+        : current,
+    );
+  };
+
+  const updateQuietHours = (field: "start" | "end", value: string) => {
+    setDraft(current =>
+      current
+        ? {
+            ...current,
+            quietHours: {
+              ...current.quietHours,
+              [field]: value,
+            },
+          }
+        : current,
+    );
+  };
+
+  const handleDigestChange = (value: string) => {
+    setDraft(current =>
+      current
+        ? {
+            ...current,
+            digest: value as NotificationPreferences["digest"],
+          }
+        : current,
+    );
+  };
+
+  const toggleQuietHours = (enabled: boolean) => {
+    setDraft(current =>
+      current
+        ? {
+            ...current,
+            quietHours: {
+              ...current.quietHours,
+              enabled,
+            },
+          }
+        : current,
+    );
+  };
+
+  const handleSave = async () => {
+    if (!draft) return;
+    const updated = await updatePreferences(draft);
+    setDraft(updated);
+    toast({
+      title: "Preferences saved",
+      description: previewLine,
+    });
+  };
+
+  if (preferencesLoading || !draft) {
+    return (
+      <Card className="rounded-2xl border bg-card/80">
+        <CardContent className="space-y-4 p-6">
+          <div className="h-4 w-40 animate-pulse rounded bg-muted" />
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, index) => (
+              <div key={`pref-skeleton-${index}`} className="h-12 animate-pulse rounded-lg bg-muted" />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card className="rounded-2xl border bg-card/80">
+        <CardHeader>
+          <CardTitle>Types you want to see</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Pick the updates that should appear in your bell and daily digest.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {(Object.keys(draft.enabled) as NotificationType[]).map(type => {
+            const meta = NOTIFICATION_TYPE_META[type];
+            const enabled = draft.enabled[type];
+            return (
+              <div
+                key={type}
+                className="flex items-start justify-between gap-4 rounded-xl border bg-background/80 p-4"
+              >
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted">
+                      <meta.icon className="h-4 w-4" />
+                    </span>
+                    <div>
+                      <p className="font-medium">{meta.label}</p>
+                      <p className="text-sm text-muted-foreground">{TYPE_DESCRIPTIONS[type]}</p>
+                    </div>
+                  </div>
+                </div>
+                <Switch checked={enabled} onCheckedChange={next => toggleType(type, Boolean(next))} />
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-2xl border bg-card/80">
+        <CardHeader>
+          <CardTitle>Urgency</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Choose which types stay pinned with a red dot until you read them.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {(Object.keys(draft.enabled) as NotificationType[]).map(type => {
+            if (!draft.enabled[type]) return null;
+            const meta = NOTIFICATION_TYPE_META[type];
+            const isHighPriority = draft.highPriority.includes(type);
+            return (
+              <button
+                key={`priority-${type}`}
+                type="button"
+                onClick={() => toggleHighPriority(type)}
+                className={cn(
+                  "flex w-full items-center justify-between rounded-xl border px-4 py-3 text-left transition",
+                  isHighPriority
+                    ? "border-destructive bg-destructive/5 text-destructive"
+                    : "bg-background/70 hover:bg-muted/60",
+                )}
+              >
+                <div className="flex items-center gap-3">
+                  <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted">
+                    <meta.icon className="h-4 w-4" />
+                  </span>
+                  <div>
+                    <p className="font-medium">{meta.label}</p>
+                    <p className="text-xs text-muted-foreground">High priority cards stay at the top.</p>
+                  </div>
+                </div>
+                <Badge
+                  variant={isHighPriority ? "destructive" : "outline"}
+                  className="rounded-full text-[10px] uppercase"
+                >
+                  {isHighPriority ? "High" : "Normal"}
+                </Badge>
+              </button>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-2xl border bg-card/80">
+        <CardHeader>
+          <CardTitle>Digest</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Get a single summary instead of many alerts.
+          </p>
+        </CardHeader>
+        <CardContent>
+          <RadioGroup value={draft.digest} onValueChange={handleDigestChange} className="space-y-3">
+            {Object.entries(DIGEST_LABELS).map(([value, label]) => (
+              <Label
+                key={value}
+                className={cn(
+                  "flex cursor-pointer items-center justify-between rounded-xl border px-4 py-3",
+                  draft.digest === value
+                    ? "border-primary bg-primary/5"
+                    : "bg-background/70 hover:bg-muted/50",
+                )}
+              >
+                <div>
+                  <p className="font-medium">{label}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {value === "off"
+                      ? "Show every notification individually."
+                      : `We'll bundle low priority updates into a ${label.toLowerCase()} summary.`}
+                  </p>
+                </div>
+                <RadioGroupItem value={value} />
+              </Label>
+            ))}
+          </RadioGroup>
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-2xl border bg-card/80">
+        <CardHeader>
+          <CardTitle>Quiet hours</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            We’ll still save them — just no pings.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between rounded-xl border bg-background/80 px-4 py-3">
+            <div>
+              <p className="font-medium">Quiet hours</p>
+              <p className="text-xs text-muted-foreground">Hold notifications outside your working window.</p>
+            </div>
+            <Switch checked={draft.quietHours.enabled} onCheckedChange={toggleQuietHours} />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Label className="space-y-2 text-sm font-medium">
+              Start
+              <Input
+                type="time"
+                value={draft.quietHours.start}
+                onChange={event => updateQuietHours("start", event.target.value)}
+                disabled={!draft.quietHours.enabled}
+              />
+            </Label>
+            <Label className="space-y-2 text-sm font-medium">
+              End
+              <Input
+                type="time"
+                value={draft.quietHours.end}
+                onChange={event => updateQuietHours("end", event.target.value)}
+                disabled={!draft.quietHours.enabled}
+              />
+            </Label>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-col gap-4 rounded-2xl border bg-card/80 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-1 text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">Preview</p>
+          <p>{previewLine}</p>
+        </div>
+        <Button onClick={handleSave} disabled={isUpdatingPreferences}>
+          {isUpdatingPreferences ? <span className="flex items-center gap-2"><span className="h-2 w-2 animate-ping rounded-full bg-white" />Saving…</span> : "Save preferences"}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/mocks/notifications-seeds.ts
+++ b/src/mocks/notifications-seeds.ts
@@ -1,0 +1,142 @@
+import { subMinutes, subHours, subDays } from "date-fns";
+import type { NotificationItem, NotificationPreferences } from "./types";
+
+const now = new Date();
+
+const iso = (date: Date) => date.toISOString();
+
+export const seedNotifications: NotificationItem[] = [
+  {
+    id: "notif_001",
+    type: "documents",
+    title: "Commercial Invoice generated",
+    context: "Shipment PL-2025-EX-0004",
+    occurredAt: iso(subMinutes(now, 3)),
+    unread: true,
+    metadata: {
+      shipmentId: "s_5004",
+      reference: "PL-2025-EX-0004",
+      docName: "Commercial Invoice",
+      docKey: "commercial_invoice",
+    },
+  },
+  {
+    id: "notif_002",
+    type: "issues",
+    title: "Issue resolved",
+    context: "Incorrect HS on Invoice · PL-2025-EX-0004",
+    occurredAt: iso(subMinutes(now, 12)),
+    unread: true,
+    metadata: {
+      issueId: "issue_204",
+      shipmentId: "s_5004",
+      severity: "high",
+    },
+  },
+  {
+    id: "notif_003",
+    type: "shipments",
+    title: "Shipment submitted",
+    context: "PL-2025-EX-0005 ready for customs review",
+    occurredAt: iso(subMinutes(now, 34)),
+    unread: false,
+    metadata: {
+      shipmentId: "s_5005",
+      reference: "PL-2025-EX-0005",
+    },
+  },
+  {
+    id: "notif_004",
+    type: "payments",
+    title: "Payment recorded",
+    context: "1,000,000 FCFA via bank transfer · PL-2025-EX-0001",
+    occurredAt: iso(subHours(now, 3)),
+    unread: true,
+    metadata: {
+      shipmentId: "s_5001",
+      reference: "PL-2025-EX-0001",
+      paymentAmount: "1,000,000 FCFA",
+      paymentMethod: "bank_transfer",
+    },
+  },
+  {
+    id: "notif_005",
+    type: "documents",
+    title: "Packing List approved",
+    context: "PL-2025-EX-0003 · Ready to export",
+    occurredAt: iso(subHours(now, 6)),
+    unread: false,
+    metadata: {
+      shipmentId: "s_5003",
+      reference: "PL-2025-EX-0003",
+      docName: "Packing List",
+      docKey: "packing_list",
+    },
+  },
+  {
+    id: "notif_006",
+    type: "system",
+    title: "Daily summary",
+    context: "3 docs generated, 1 issue opened, 2 shipments updated",
+    occurredAt: iso(subHours(now, 9)),
+    unread: false,
+    isDigest: true,
+    metadata: {
+      digestBreakdown: [
+        { type: "documents", label: "Documents", value: "3 generated" },
+        { type: "issues", label: "Issues", value: "1 opened" },
+        { type: "shipments", label: "Shipments", value: "2 updated" },
+      ],
+    },
+  },
+  {
+    id: "notif_007",
+    type: "issues",
+    title: "Issue opened",
+    context: "Missing certificate of origin · PL-2025-EX-0002",
+    occurredAt: iso(subHours(now, 18)),
+    unread: false,
+    metadata: {
+      issueId: "issue_187",
+      shipmentId: "s_5002",
+      severity: "medium",
+    },
+  },
+  {
+    id: "notif_008",
+    type: "shipments",
+    title: "Shipment cleared",
+    context: "PL-2025-EX-0001 released at Douala",
+    occurredAt: iso(subDays(now, 1)),
+    unread: false,
+    metadata: {
+      shipmentId: "s_5001",
+      reference: "PL-2025-EX-0001",
+    },
+  },
+  {
+    id: "notif_009",
+    type: "system",
+    title: "System maintenance scheduled",
+    context: "Planned downtime on 18 Jan, 22:00-23:00 WAT",
+    occurredAt: iso(subDays(now, 2)),
+    unread: false,
+  },
+];
+
+export const defaultNotificationPreferences: NotificationPreferences = {
+  enabled: {
+    documents: true,
+    issues: true,
+    shipments: true,
+    payments: true,
+    system: true,
+  },
+  highPriority: ["issues"],
+  digest: "daily",
+  quietHours: {
+    enabled: false,
+    start: "21:00",
+    end: "07:00",
+  },
+};

--- a/src/mocks/types.ts
+++ b/src/mocks/types.ts
@@ -133,3 +133,47 @@ export interface AppUserSummary {
   role: AppRole;
   created_at: string;
 }
+
+export type NotificationType = "documents" | "issues" | "shipments" | "payments" | "system";
+
+export type NotificationDigestFrequency = "daily" | "weekly" | "off";
+
+export interface NotificationDigestEntry {
+  type: NotificationType;
+  label: string;
+  value: string;
+}
+
+export interface NotificationMetadata {
+  shipmentId?: string;
+  reference?: string;
+  docKey?: DocKey;
+  docName?: string;
+  issueId?: string;
+  severity?: IssueSeverity;
+  paymentAmount?: string;
+  paymentMethod?: PaymentMethod;
+  digestBreakdown?: NotificationDigestEntry[];
+}
+
+export interface NotificationItem {
+  id: string;
+  type: NotificationType;
+  title: string;
+  context: string;
+  occurredAt: string;
+  unread: boolean;
+  isDigest?: boolean;
+  metadata?: NotificationMetadata;
+}
+
+export interface NotificationPreferences {
+  enabled: Record<NotificationType, boolean>;
+  highPriority: NotificationType[];
+  digest: NotificationDigestFrequency;
+  quietHours: {
+    enabled: boolean;
+    start: string;
+    end: string;
+  };
+}


### PR DESCRIPTION
## Summary
- seed the mock API with notification items and preference defaults, along with new types and endpoints
- add a bell-driven activity panel plus a full notifications workspace with filters, triage actions, and reusable UI constants
- introduce notification preference controls under Settings with quiet hours, digest cadence, and high-priority toggles

## Testing
- npm run build
- npm run lint *(fails: existing lint errors in untouched files)*
- npx eslint src/features/notifications --max-warnings=0

------
https://chatgpt.com/codex/tasks/task_e_68d1ab5c02ec8324b6c1a9a365c8777b