### PR TITLE
Add dark mode toggle in app header

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -47,6 +47,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { useQuery } from '@tanstack/react-query';
 import { mockApi } from '@/mocks/api';
 import { NotificationsBell } from '@/features/notifications/components/NotificationsBell';
+import { ThemeToggle } from '@/components/layout/ThemeToggle';
 
 const sidebarItems = [
   { title: 'Dashboard', url: '/app', icon: LayoutDashboard, active: true },
@@ -175,7 +176,8 @@ export const AppShell = () => {
             </div>
 
             {/* User Menu */}
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-3">
+              <ThemeToggle />
               <NotificationsBell />
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,35 @@
+import { Moon, Sun } from "lucide-react";
+
+import { Switch } from "@/components/ui/switch";
+import { useTheme } from "@/hooks/useTheme";
+import { cn } from "@/lib/utils";
+
+export const ThemeToggle = () => {
+  const { theme, setTheme } = useTheme();
+  const isDark = theme === "dark";
+
+  return (
+    <div className="flex items-center rounded-full border border-border/70 bg-muted/60 px-2 py-1 text-muted-foreground">
+      <Sun
+        className={cn(
+          "mr-1 h-4 w-4 transition-opacity",
+          isDark ? "opacity-30" : "opacity-100 text-amber-400",
+        )}
+        aria-hidden
+      />
+      <Switch
+        checked={isDark}
+        onCheckedChange={(checked) => setTheme(checked ? "dark" : "light")}
+        aria-label="Toggle dark mode"
+        className="h-5 w-9"
+      />
+      <Moon
+        className={cn(
+          "ml-1 h-4 w-4 transition-opacity",
+          isDark ? "opacity-100 text-sky-400" : "opacity-30",
+        )}
+        aria-hidden
+      />
+    </div>
+  );
+};

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  applyThemePreference,
+  getThemePreference,
+  persistThemePreference,
+  type ThemePreference,
+} from "@/utils/theme";
+
+export const useTheme = () => {
+  const [theme, setThemeState] = useState<ThemePreference>(() => getThemePreference());
+
+  useEffect(() => {
+    applyThemePreference(theme);
+    persistThemePreference(theme);
+  }, [theme]);
+
+  const setTheme = useCallback((next: ThemePreference) => {
+    setThemeState(next);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState(current => (current === "dark" ? "light" : "dark"));
+  }, []);
+
+  return {
+    theme,
+    setTheme,
+    toggleTheme,
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,9 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
-import { ensureInitialBrandApplied } from "@/utils/theme";
+import { ensureInitialBrandApplied, ensureInitialThemeApplied } from "@/utils/theme";
 
+ensureInitialThemeApplied();
 ensureInitialBrandApplied();
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,7 +1,56 @@
 import type { BrandSettings } from "@/mocks/types";
-import { getFromStorage } from "@/utils/storage";
+import { getFromStorage, setToStorage } from "@/utils/storage";
 
 const STORAGE_KEY = "brand_settings";
+const THEME_STORAGE_KEY = "theme_preference";
+
+const isBrowser = typeof window !== "undefined";
+const isDocument = typeof document !== "undefined";
+
+export type ThemePreference = "light" | "dark";
+
+const getSystemThemePreference = (): ThemePreference => {
+  if (!isBrowser) {
+    return "light";
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+};
+
+export const getThemePreference = (): ThemePreference => {
+  const stored = getFromStorage<ThemePreference | null>(THEME_STORAGE_KEY, null);
+  return stored ?? getSystemThemePreference();
+};
+
+export const applyThemePreference = (theme: ThemePreference) => {
+  if (!isDocument) {
+    return;
+  }
+
+  const root = document.documentElement;
+
+  if (theme === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+
+  root.setAttribute("data-theme", theme);
+  root.style.colorScheme = theme;
+};
+
+export const persistThemePreference = (theme: ThemePreference) => {
+  if (!isBrowser) {
+    return;
+  }
+
+  setToStorage(THEME_STORAGE_KEY, theme);
+};
+
+export const ensureInitialThemeApplied = () => {
+  const theme = getThemePreference();
+  applyThemePreference(theme);
+};
 
 type HslTuple = {
   h: number;


### PR DESCRIPTION
## Summary
- add utilities for resolving and persisting the current theme preference
- ensure the saved theme is applied on app startup and expose a reusable `useTheme` hook
- introduce a compact header toggle so users can switch between light and dark modes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d1ca75842c8324afe76316876fdf30