### PR TITLE
Enable navigation for HS Codes, Reports, and Settings pages

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -51,12 +51,12 @@ import { NotificationsBell } from '@/features/notifications/components/Notificat
 const sidebarItems = [
   { title: 'Dashboard', url: '/app', icon: LayoutDashboard, active: true },
   { title: 'Shipments', url: '/shipments', icon: Package, disabled: false },
-  { title: 'HS Codes', url: '/hs', icon: Hash, disabled: true },
+  { title: 'HS Codes', url: '/hs', icon: Hash, disabled: false },
   { title: 'Documents', url: '/documents', icon: FileText, disabled: false },
   { title: 'Issues', url: '/issues', icon: AlertTriangle, disabled: true },
-  { title: 'Reports', url: '/reports', icon: BarChart3, disabled: true },
+  { title: 'Reports', url: '/reports', icon: BarChart3, disabled: false },
   { title: 'Notifications', url: '/notifications', icon: Bell, disabled: false },
-  { title: 'Settings', url: '/settings', icon: Settings, disabled: true },
+  { title: 'Settings', url: '/settings', icon: Settings, disabled: false },
 ];
 
 const AppSidebar = () => {


### PR DESCRIPTION
## Summary
- update sidebar configuration so HS Codes, Reports, and Settings buttons are enabled again

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d25b6be08324936c5df546e5b18f