### PR TITLE
Add floating theme toggle button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { useEffect } from "react";
 import { LandingPage } from "@/features/landing/LandingPage";
 import { LoginPage } from "@/features/auth/LoginPage";
 import { AppShell } from "@/components/layout/AppShell";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import { DashboardPage } from "@/features/dashboard/DashboardPage";
 import { ReportsPage } from "@/features/reports/ReportsPage";
 import { HsCodesPage } from "@/features/hs/HsCodesPage";
@@ -47,6 +48,7 @@ const App = () => {
     <BrowserRouter basename={import.meta.env.BASE_URL}>
       <QueryClientProvider client={queryClient}>
         <TooltipProvider>
+          <ThemeToggle />
           <Toaster />
           <Sonner />
           <Routes>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { getFromStorage, setToStorage } from "@/utils/storage";
+
+const THEME_STORAGE_KEY = "theme_preference";
+
+type ThemeMode = "light" | "dark";
+
+const getInitialTheme = (): ThemeMode => {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  const stored = getFromStorage<string>(THEME_STORAGE_KEY, "light");
+  if (stored === "dark" || stored === "light") {
+    return stored;
+  }
+
+  const prefersDark = typeof window.matchMedia === "function"
+    ? window.matchMedia("(prefers-color-scheme: dark)").matches
+    : false;
+
+  if (prefersDark) {
+    return "dark";
+  }
+
+  return "light";
+};
+
+export const ThemeToggle = () => {
+  const [theme, setTheme] = useState<ThemeMode>(getInitialTheme);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    document.documentElement.classList.toggle("dark", theme === "dark");
+
+    if (typeof window !== "undefined") {
+      setToStorage(THEME_STORAGE_KEY, theme);
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((current) => (current === "light" ? "dark" : "light"));
+  };
+
+  const nextTheme = theme === "light" ? "dark" : "light";
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      className="fixed right-4 top-4 z-50 h-9 w-9 rounded-full bg-background/90 shadow-sm backdrop-blur"
+      onClick={toggleTheme}
+      aria-label={`Switch to ${nextTheme} mode`}
+      title={`Switch to ${nextTheme} mode`}
+    >
+      {theme === "light" ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}
+    </Button>
+  );
+};


### PR DESCRIPTION
## Summary
- add a floating theme toggle button that sits at the top-right of the viewport
- persist the chosen theme in local storage and apply it to the document root

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d7c8ee8c832483339eca5bac262d